### PR TITLE
Fix token permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-20.04
     permissions:
       repository-projects: read
+      contents: read
     if: github.repository == 'falgon/roki-web'
     steps:
     - name: Checkout

--- a/.github/workflows/build_pr.yml
+++ b/.github/workflows/build_pr.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-20.04
     permissions:
       repository-projects: read
+      contents: read
     outputs:
       target_ref: ${{ steps.build.outputs.target_ref }}
     steps:


### PR DESCRIPTION
If it not set `contents:read` to permission, it will not be able to git checkout in private repository
