### PR TITLE
refactor: ホテル詳細データを任意階層対応にリファクタリング

### DIFF
--- a/contents/config/disney/Hotels.dhall
+++ b/contents/config/disney/Hotels.dhall
@@ -1,50 +1,146 @@
--- ホテルの詳細情報を階層的に表現する型（シンプル版）
--- 子要素はテキストのリストとして表現
-let HotelDetail =
-      < HDText : Text | HDNode : { hdLabel : Text, hdChildren : List Text } >
+-- 任意の深さのホテル詳細をChurchエンコードで表現する
+let HotelDetailF =
+      λ(r : Type) →
+      < HDText : Text | HDNode : { hdLabel : Text, hdChildren : List r } >
+
+let HotelDetail = ∀(r : Type) → (HotelDetailF r → r) → r
+
+let foldHotelDetail =
+      λ(r : Type) →
+      λ(alg : HotelDetailF r → r) →
+      λ(detail : HotelDetail) →
+        detail r alg
+
+let listMap =
+      λ(a : Type) →
+      λ(b : Type) →
+      λ(f : a → b) →
+      λ(xs : List a) →
+        List/fold
+          a
+          xs
+          (List b)
+          (λ(x : a) → λ(acc : List b) → [ f x ] # acc)
+          ([] : List b)
+
+let listConcat =
+      λ(a : Type) →
+      λ(xss : List (List a)) →
+        List/fold
+          (List a)
+          xss
+          (List a)
+          (λ(xs : List a) → λ(acc : List a) → xs # acc)
+          ([] : List a)
+
+let prependToEach =
+      λ(prefix : Text) →
+      λ(paths : List (List Text)) →
+        listMap
+          (List Text)
+          (List Text)
+          (λ(path : List Text) → [ prefix ] # path)
+          paths
+
+let detailToPaths : HotelDetail → List (List Text) =
+      foldHotelDetail
+        (List (List Text))
+        (λ(detailF : HotelDetailF (List (List Text))) →
+          merge
+            { HDText = λ(text : Text) → [ [ text ] ]
+            , HDNode =
+                λ(node : { hdLabel : Text, hdChildren : List (List (List Text)) }) →
+                  let childPaths =
+                        listConcat
+                          (List Text)
+                          node.hdChildren
+                  in  prependToEach node.hdLabel childPaths
+            }
+            detailF
+        )
+
+let detailsToPaths =
+      λ(details : List HotelDetail) →
+        listConcat
+          (List Text)
+          (listMap
+            HotelDetail
+            (List (List Text))
+            detailToPaths
+            details
+          )
+
+let makeText : Text → HotelDetail =
+      λ(text : Text) →
+      λ(r : Type) →
+      λ(alg : HotelDetailF r → r) →
+        alg ((HotelDetailF r).HDText text)
+
+let makeNode : Text → List HotelDetail → HotelDetail =
+      λ(label : Text) →
+      λ(children : List HotelDetail) →
+      λ(r : Type) →
+      λ(alg : HotelDetailF r → r) →
+        let mappedChildren =
+              listMap
+                HotelDetail
+                r
+                (λ(child : HotelDetail) → child r alg)
+                children
+        in  alg
+              ((HotelDetailF r).HDNode
+                { hdLabel = label, hdChildren = mappedChildren })
 
 let Hotel =
-      { hotelCode : Text
-      , stays : Natural
-      , details : List HotelDetail
-      , hotelColor : Text
+      { hotelCodeRaw : Text
+      , staysRaw : Natural
+      , detailsRaw : List (List Text)
+      , hotelColorRaw : Text
       }
 
-in  [ { hotelCode = "FSH"
-      , stays = 4
-      , details =
-        [ HotelDetail.HDText "ファンタジーシャトー"
-        , HotelDetail.HDNode { hdLabel = "スプリングスサイド", hdChildren = [ "バルアル" ] }
-        , HotelDetail.HDNode
-            { hdLabel = "ローズコートサイド"
-            , hdChildren = [ "スーペリア ×2", "スーペリア・アルコーヴ" ]
-            }
-        ]
-      , hotelColor = "#854454"
+in  [ { hotelCodeRaw = "FSH"
+      , staysRaw = 4
+      , detailsRaw =
+        detailsToPaths
+          [ makeNode
+              "ファンタジーシャトー"
+              [ makeNode "スプリングスサイド" [ makeText "バルアル" ]
+              , makeNode
+                  "ローズコートサイド"
+                  [ makeText "スーペリア ×2", makeText "スーペリア・アルコーヴ" ]
+              ]
+          ]
+      , hotelColorRaw = "#854454"
       }
-    , { hotelCode = "DHM"
-      , stays = 4
-      , details =
-        [ HotelDetail.HDNode
-            { hdLabel = "スイート", hdChildren = [ "ハバテラ ×2", "ピアバル" ] }
-        , HotelDetail.HDNode
-            { hdLabel = "ポルトパラディーゾ", hdChildren = [ "スーペリアルームハーバービュー" ] }
-        ]
-      , hotelColor = "#8A7501"
+    , { hotelCodeRaw = "DHM"
+      , staysRaw = 4
+      , detailsRaw =
+        detailsToPaths
+          [ makeNode
+              "スイート"
+              [ makeText "ハバテラ ×2", makeText "ピアバル" ]
+          , makeNode
+              "ポルトパラディーゾ"
+              [ makeText "スーペリアルームハーバービュー" ]
+          ]
+      , hotelColorRaw = "#8A7501"
       }
-    , { hotelCode = "TDH"
-      , stays = 4
-      , details =
-        [ HotelDetail.HDNode
-            { hdLabel = "キャラ", hdChildren = [ "美女野獣", "シンデレラ" ] }
-        , HotelDetail.HDNode
-            { hdLabel = "スーペリア", hdChildren = [ "コーナールーム", "パークグランドビュー" ] }
-        ]
-      , hotelColor = "#B95C00"
+    , { hotelCodeRaw = "TDH"
+      , staysRaw = 4
+      , detailsRaw =
+        detailsToPaths
+          [ makeNode
+              "キャラ"
+              [ makeText "美女野獣", makeText "シンデレラ" ]
+          , makeNode
+              "スーペリア"
+              [ makeText "コーナールーム", makeText "パークグランドビュー" ]
+          ]
+      , hotelColorRaw = "#B95C00"
       }
-    , { hotelCode = "TSH"
-      , stays = 3
-      , details = [ HotelDetail.HDText "スタンダードルーム ×3" ]
-      , hotelColor = "#C28A02"
+    , { hotelCodeRaw = "TSH"
+      , staysRaw = 3
+      , detailsRaw = detailsToPaths [ makeText "スタンダードルーム ×3" ]
+      , hotelColorRaw = "#C28A02"
       }
     ]


### PR DESCRIPTION
Church encodingを使用して任意の深さの階層構造を表現できるように改善。
Dhall側でChurch encodingによる再帰型を実装し、Haskell側でパスリストから
階層構造を復元する仕組みを構築。

主な変更:
- HotelDetail型をChurch encodingで再定義
- detailToPathsでフラット化、buildHotelDetailsで階層復元
- FSHホテルの3階層構造を正確に表現
- 既存データの整合性を維持

🤖 Generated with Claude Code
https://claude.ai/code

Co-Authored-By: Claude <noreply@anthropic.com>
