### PR TITLE
feat: トップページにSite Informationモーダルを追加 (#566)

### DIFF
--- a/contents/about/sitemap.md
+++ b/contents/about/sitemap.md
@@ -1,0 +1,17 @@
+```{lang=mermaid}
+graph TD;
+    s[roki.dev]
+    s[roki.dev]---b1[roki.log]
+    s---b2[roki.diary]
+    s---r[resume]
+    s---d[Disney Experience Summary]
+    subgraph "Blogs"
+    b1
+    b2
+    end
+    click s "https://roki.dev"
+    click b1 "https://roki.dev/roki.log"
+    click b2 "https://roki.dev/roki.diary"
+    click r "https://roki.dev/resume"
+    click d "https://roki.dev/disney_experience_summary/jp.html"
+```

--- a/contents/about/updates.md
+++ b/contents/about/updates.md
@@ -1,0 +1,4 @@
+| Date | Summary | PR |
+|------|---------|-----|
+| 2024-09-11 | Mermaidレンダリング機能追加 | [#591](https://github.com/falgon/roki-web/pull/591) |
+| 2024-08-21 | Docker multistage build対応 | [#726](https://github.com/falgon/roki-web/pull/726) |

--- a/contents/pages/index.html
+++ b/contents/pages/index.html
@@ -1,5 +1,6 @@
 $partial("contents/templates/site/contributions.html")$
 $partial("contents/templates/site/donate.html")$
+$partial("contents/templates/site/about.html")$
 
 <div class="content">
     $partial("contents/templates/site/pc.html")$

--- a/contents/templates/site/about.html
+++ b/contents/templates/site/about.html
@@ -1,0 +1,31 @@
+<div class="modal" id="modal-about">
+    <div class="modal-background"></div>
+    <div class="modal-card">
+        <header class="modal-card-head">
+            <p class="modal-card-title">
+                <i class="fas fa-sitemap fa-fw mr-2"></i>
+                Site Information
+            </p>
+            <button class="delete" aria-label="close"></button>
+        </header>
+        <section class="modal-card-body">
+            <h2 class="title is-3">
+                <i class="fas fa-sitemap fa-fw"></i>
+                Site Map
+            </h2>
+            <div class="content">
+                $sitemap-body$
+            </div>
+
+            <hr />
+
+            <h2 class="title is-3">
+                <i class="fas fa-clock-rotate-left fa-fw"></i>
+                System Updates
+            </h2>
+            <div class="content">
+                $updates-body$
+            </div>
+        </section>
+    </div>
+</div>

--- a/contents/templates/site/author-info/listed.html
+++ b/contents/templates/site/author-info/listed.html
@@ -7,5 +7,6 @@
     <li><i class="fas fa-tags fa-fw mr-2" aria-hidden="true"></i><span class="has-tooltip-arrow has-tooltipl-multiline has-tooltip-text-left has-tooltip-bottom" data-tooltip="$author-interested$">Interested in…</span></li>
     <li><i class="fas fa-heart fa-fw mr-2" aria-hidden="true"></i>$author-fav$</li>
     <li><i class="fas fa-coins fa-fw mr-2"></i><a class="modal-target" data-target="modal-donate">Donate</a></li>
+    <li><i class="fas fa-sitemap fa-fw mr-2"></i><a class="modal-target" data-target="modal-about">Site Information</a></li>
     <li>$partial("contents/templates/site/author-info/more-links.html")$</li>
 </ul>

--- a/src/Rules/TopPage.hs
+++ b/src/Rules/TopPage.hs
@@ -8,14 +8,16 @@ import           Data.List.Extra      (mconcatMap)
 import           Data.Time.Format     (formatTime)
 import           Hakyll
 import           System.FilePath      (joinPath, (</>))
+import           Text.Pandoc.Walk     (walkM)
 
 import           Config               (contentsRoot, defaultTimeLocale',
-                                       siteName)
+                                       readerOptions, siteName)
 import           Config.Blog
 import           Config.Contributions
 import           Config.TopPage
 import           Contexts             (siteCtx)
 import qualified Contexts.Blog        as CtxBlog
+import           Media.SVG            (mermaidTransform)
 import           Rules.Blog.Type
 import           Rules.PageType
 import           Utils                (mconcatM, modifyExternalLinkAttr)
@@ -50,27 +52,45 @@ mkBlogCtx = do
       , pure defaultContext
       ]
 
+aboutSnapshot :: Snapshot
+aboutSnapshot = "aboutSS"
+
 rules :: [BlogConfig m] -> PageConfReader Rules ()
 rules bcs = do
     faIcons <- asks pcFaIcons
+    wOpt <- asks pcWriterOpt
     projs <- lift $ preprocess renderProjectsList
     conts <- lift $ preprocess renderContributionsTable
-    let baseCtx = mconcatMap (uncurry constField) [
-            ("title", siteName)
-          , ("projs", projs)
-          , ("contable", conts)
-          ]
-    lift $ match indexPath $ do
-        route $ gsubRoute (contentsRoot </> "pages/") (const mempty)
-        compile $ do
-            topCtx <- mappend baseCtx <$> mconcatMapM (runReaderT mkBlogCtx) bcs
-            getResourceBody
-                >>= applyAsTemplate topCtx
-                >>= loadAndApplyTemplate rootTemplate topCtx
-                >>= modifyExternalLinkAttr
-                >>= relativizeUrls
-                >>= FA.render faIcons
+    lift $ do
+        match aboutPattern $ compile $
+            pandocCompilerWithTransformM readerOptions wOpt (walkM mermaidTransform)
+                >>= saveSnapshot aboutSnapshot
+        match indexPath $ do
+            route $ gsubRoute (contentsRoot </> "pages/") (const mempty)
+            compile $ do
+                let baseCtx = mconcatMap (uncurry constField) [
+                        ("title", siteName)
+                      , ("projs", projs)
+                      , ("contable", conts)
+                      ]
+                topCtx <- mconcatM [
+                        pure baseCtx
+                      , mconcatMapM (runReaderT mkBlogCtx) bcs
+                      , constField "sitemap-body"
+                            <$> loadSnapshotBody sitemapIdent aboutSnapshot
+                      , constField "updates-body"
+                            <$> loadSnapshotBody updatesIdent aboutSnapshot
+                      ]
+                getResourceBody
+                    >>= applyAsTemplate topCtx
+                    >>= loadAndApplyTemplate rootTemplate topCtx
+                    >>= modifyExternalLinkAttr
+                    >>= relativizeUrls
+                    >>= FA.render faIcons
     where
+        aboutPattern = fromGlob $ joinPath [contentsRoot, "about", "*.md"]
+        sitemapIdent = fromFilePath $ joinPath [contentsRoot, "about", "sitemap.md"]
+        updatesIdent = fromFilePath $ joinPath [contentsRoot, "about", "updates.md"]
         indexPath = fromGlob $ joinPath [contentsRoot, "pages", "index.html"]
         rootTemplate = fromFilePath $ joinPath [contentsRoot, "templates", "site", "default.html"]
 


### PR DESCRIPTION
- サイトマップ図（mermaid）とシステム更新記録を表示するモーダルを追加
- 左サイドバーにSite Informationリンクを配置（Donateの下）
- contents/about/sitemap.md: mermaid形式のサイトマップ図
- contents/about/updates.md: システム更新記録のテーブル
- src/Rules/TopPage.hs: aboutページのmarkdownをコンパイルしてレンダリング
- mermaidTransformによりmermaid図をSVGに変換

Co-Authored-By: Claude <noreply@anthropic.com>
