### PR TITLE
fix: Skickaキャッシュバージョンを更新してOAuthトークン問題を解決

### DIFF
--- a/.github/workflows/build_pr.yml
+++ b/.github/workflows/build_pr.yml
@@ -228,7 +228,7 @@ jobs:
           ~/.skicka.tokencache.json
           ~/.skicka.config
           ~/.skicka.metadata.cache
-        key: go-${{ env.GO_VERSION }}-v3-${{ runner.os }}
+        key: go-${{ env.GO_VERSION }}-v4-${{ runner.os }}
     - name: Setup Go Path
       run: |
         echo "GOPATH=$HOME/.go" >> "$GITHUB_ENV"


### PR DESCRIPTION
- GitHub ActionsのSkickaキャッシュキーをv3からv4に更新
- 古いOAuthトークンがキャッシュから復元される問題を修正
- Google Drive APIアクセスエラー "unsupported protocol scheme" を解消

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
