### PR TITLE
feat: ディズニー宿泊概算に集計開始年の注記を追加、Contributionsにhakyll PRを追加

### DIFF
--- a/contents/config/contributions/Contributions.dhall
+++ b/contents/config/contributions/Contributions.dhall
@@ -63,5 +63,10 @@ in    [ { text = "cpprefjp: Fix typo #388"
         , genre = g.genreToText (g.Genre.Dhall {=})
         , date = { yyyy = 2020, mm = 9, dd = 11 }
         }
+      , { text = "jaspervdj/hakyll: Add example website"
+        , link = "https://github.com/jaspervdj/hakyll/pull/1082"
+        , genre = g.genreToText (g.Genre.Haskell {=})
+        , date = { yyyy = 2025, mm = 10, dd = 1 }
+        }
       ]
     : List ./Type/Contribute.dhall

--- a/contents/pages/disney_experience_summary/jp.html
+++ b/contents/pages/disney_experience_summary/jp.html
@@ -180,6 +180,7 @@
     <div class="hotel-summary-section">
         <h3 class="title is-4 mb-3">
             <i class="fas fa-bed"></i>宿泊概算
+            <span style="font-size: 0.75rem; color: #666; margin-left: 0.5rem;">※ 2024年からの集計</span>
             <span class="hotel-summary-total-inline">
                 <div class="hotel-summary-stats">
                     <div class="stat-total">


### PR DESCRIPTION
- disney_experience_summary/jp.html: 「宿泊概算」の横に「※ 2024年からの集計」の注記を追加
- Contributions.dhall: jaspervdj/hakyll #1082 (Add example website) を追加

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
