### PR TITLE
設定: dependabot で vitest 関連パッケージをグループ化

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,3 +20,8 @@ updates:
       - "automerge"
     pull-request-branch-name:
       separator: "/"
+    groups:
+      vitest:
+        patterns:
+          - "vitest"
+          - "@vitest/*"


### PR DESCRIPTION
vitest, @vitest/ui, @vitest/coverage-v8 を groups 機能で
グループ化し、これらのパッケージの更新を1つのPRでまとめる。

- groups セクションを dependabot.yml に追加
- vitest グループを定義（vitest と @vitest/* パターン）

Co-Authored-By: Claude <noreply@anthropic.com>
