### PR TITLE
improve(disney): ボタンとAIタグのUI調整

### DIFF
--- a/contents/pages/disney_experience_summary/jp.html
+++ b/contents/pages/disney_experience_summary/jp.html
@@ -88,13 +88,13 @@
     <div class="favorite-category mt-4">
         <h3 class="title is-4 mb-3">
             <i class="fas fa-wand-magic-sparkles"></i>体験歴
-            <button class="button is-small is-info ml-2" id="toggle-search-filter" aria-expanded="false" aria-controls="search-filter" aria-label="キーワード検索フィルターの表示/非表示">
+            <button class="button is-small is-info ml-1" id="toggle-search-filter" aria-expanded="false" aria-controls="search-filter" aria-label="キーワード検索フィルターの表示/非表示">
                 <span class="icon" aria-hidden="true">
                     <i class="fas fa-search"></i>
                 </span>
                 <span>キーワード検索</span>
             </button>
-            <button class="button is-small is-info ml-2" id="toggle-tag-filter" aria-expanded="false" aria-controls="tag-filter" aria-label="タグ絞り込みフィルターの表示/非表示">
+            <button class="button is-small is-info ml-1" id="toggle-tag-filter" aria-expanded="false" aria-controls="tag-filter" aria-label="タグ絞り込みフィルターの表示/非表示">
                 <span class="icon" aria-hidden="true">
                     <i class="fas fa-filter"></i>
                 </span>
@@ -147,7 +147,14 @@
         <div class="logs">
             $for(disney-logs)$
             <article class="log-entry" data-tags="$for(disney-tags-list)$$name$$sep$,$endfor$" data-search-content="$title$ $log-body$">
-                <h2 class="log-title">$title$</h2>
+                <div class="log-title-row">
+                    <h2 class="log-title">$title$</h2>
+                    $for(ai-generated-badges)$
+                    <span class="ai-generated-badge">
+                        <i class="fas fa-robot"></i> $badge-text$
+                    </span>
+                    $endfor$
+                </div>
                 $if(disney-tags-list)$
                 <div class="log-tags">
                     $for(disney-tags-list)$
@@ -179,11 +186,6 @@
                     <a href="$url$" target="_blank" rel="noopener" title="Note"><i class="fas fa-note-sticky fa-sm"></i></a>
                     $endfor$
                     $endif$
-                    $for(ai-generated-badges)$
-                    <span class="ai-generated-badge">
-                        <i class="fas fa-robot"></i> $badge-text$
-                    </span>
-                    $endfor$
                 </div>
                 <div class="log-body">$log-body$</div>
             </article>

--- a/contents/scss/disney_experience_summary_only.scss
+++ b/contents/scss/disney_experience_summary_only.scss
@@ -136,6 +136,40 @@ $button-small-font-size-mobile: 0.65rem;
         border-radius: 8px;
     }
 
+    .log-title-row {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        flex-wrap: wrap;
+        margin-bottom: 0.5rem;
+        
+        .log-title {
+            flex: 1;
+            min-width: 0;
+            word-wrap: break-word;
+            overflow-wrap: break-word;
+            margin-bottom: 0;
+        }
+        
+        .ai-generated-badge {
+            flex-shrink: 0;
+            padding: 0.2rem 0.6rem;
+            background: linear-gradient(135deg, #3CAADF 0%, #3e8ed0 100%);
+            color: white;
+            border-radius: 12px;
+            font-size: 0.7rem;
+            font-weight: 500;
+            display: inline-flex;
+            align-items: center;
+            gap: 0.25rem;
+            white-space: nowrap;
+            
+            i {
+                font-size: 0.75rem;
+            }
+        }
+    }
+
     .log-title {
         font-size: 1.2rem;
         font-weight: bold;
@@ -197,25 +231,6 @@ $button-small-font-size-mobile: 0.65rem;
             
             &.fa-x-twitter:hover {
                 color: #000000;
-            }
-        }
-        
-        .ai-generated-badge {
-            margin-left: auto;
-            flex-shrink: 0;  // バッジも縮小しないように
-            padding: 0.15rem 0.5rem;
-            background: linear-gradient(135deg, #3CAADF 0%, #3e8ed0 100%);
-            color: white;
-            border-radius: 12px;
-            font-size: 0.7rem;
-            font-weight: 500;
-            display: inline-flex;
-            align-items: center;
-            gap: 0.25rem;
-            box-shadow: 0 2px 4px rgba(60, 170, 223, 0.3);
-            
-            i {
-                font-size: 0.75rem;
             }
         }
     }
@@ -306,8 +321,8 @@ $button-small-font-size-mobile: 0.65rem;
                     height: 1em !important;
                     flex-shrink: 0 !important;
                     line-height: 1 !important;
-                    margin-left: 0.2rem !important;
-                    margin-right: 0.5rem !important;
+                    margin-left: 0.1rem !important;
+                    margin-right: 0.35rem !important;
                     transition: none !important;
                     
                     i, svg {
@@ -921,6 +936,12 @@ $button-small-font-size-mobile: 0.65rem;
 
 @media screen and (max-width: 768px) {
     .disney-experience-summary {
+        .log-title-row {
+            flex-direction: column;
+            align-items: flex-start;
+            gap: 0.5rem;
+        }
+
         .favorite-category {
             h3 {
                 gap: 0.3rem;


### PR DESCRIPTION
- ボタンマージンをml-2からml-1に縮小（キーワード検索、タグで絞り込み）
- アイコン間隔を調整（margin-left: 0.1rem, margin-right: 0.35rem）
- AIタグをタイトルと同じ行に配置するよう構造変更
- タイトル長時の折り返し対応を実装
- モバイルでの縦積み表示に対応

Co-authored-by: Claude <noreply@anthropic.com>
