### PR TITLE
feat/disney ux improvements

### DIFF
--- a/contents/pages/disney_experience_summary/jp.html
+++ b/contents/pages/disney_experience_summary/jp.html
@@ -87,41 +87,59 @@
 
     <!-- 体験コーナー統合セクション -->
     <div class="experience-hub mt-4">
-        <!-- タイトル行：最終更新日をタイトル右端に配置 -->
+        <!-- タイトル行：最終更新日をバッジスタイルで表示 -->
         <div class="title-wrapper mb-3">
             <h3 class="title is-4 mb-0">
                 <i class="fas fa-wand-magic-sparkles"></i>体験録
             </h3>
-            <div class="title-meta">
-                <span class="updated-label">最終更新日:</span> $logs-last-modified$
-            </div>
+            <span class="badge badge-info">
+                <i class="fas fa-clock"></i> 最終更新: $logs-last-modified$
+            </span>
         </div>
 
-        <!-- 3タブナビゲーション -->
+        <!-- 4タブナビゲーション -->
         <div class="tabs is-boxed" role="tablist" aria-label="体験データタブ">
             <ul>
                 <li class="is-active" data-tab="list">
                     <a role="tab" id="tab-list" aria-controls="panel-list" aria-selected="true" tabindex="0">
                         <span class="icon is-small"><i class="fas fa-list" aria-hidden="true"></i></span>
-                        <span>一覧</span>
+                        <span class="tab-label">
+                            <span class="tab-label-main">一覧</span>
+                            <small class="tab-label-desc">全体験録を表示</small>
+                        </span>
                     </a>
                 </li>
                 <li data-tab="timeline">
                     <a role="tab" id="tab-timeline" aria-controls="panel-timeline" aria-selected="false" tabindex="-1">
                         <span class="icon is-small"><i class="fas fa-calendar-days" aria-hidden="true"></i></span>
-                        <span>体験タイムライン</span>
+                        <span class="tab-label">
+                            <span class="tab-label-main">
+                                <span class="is-hidden-mobile">体験タイムライン</span>
+                                <span class="is-hidden-tablet">タイムライン</span>
+                            </span>
+                            <small class="tab-label-desc">時系列で可視化</small>
+                        </span>
                     </a>
                 </li>
                 <li data-tab="tags">
                     <a role="tab" id="tab-tags" aria-controls="panel-tags" aria-selected="false" tabindex="-1">
                         <span class="icon is-small"><i class="fas fa-circle-nodes" aria-hidden="true"></i></span>
-                        <span>タグ別体験頻度</span>
+                        <span class="tab-label">
+                            <span class="tab-label-main">
+                                <span class="is-hidden-mobile">タグ別体験頻度</span>
+                                <span class="is-hidden-tablet">タグ頻度</span>
+                            </span>
+                            <small class="tab-label-desc">タグ別で可視化</small>
+                        </span>
                     </a>
                 </li>
                 <li data-tab="hotels">
                     <a role="tab" id="tab-hotels" aria-controls="panel-hotels" aria-selected="false" tabindex="-1">
                         <span class="icon is-small"><i class="fas fa-bed" aria-hidden="true"></i></span>
-                        <span>宿泊概算</span>
+                        <span class="tab-label">
+                            <span class="tab-label-main">宿泊概算</span>
+                            <small class="tab-label-desc">ホテル別集計</small>
+                        </span>
                     </a>
                 </li>
             </ul>
@@ -143,6 +161,7 @@
                             <i class="fas fa-filter"></i>
                         </span>
                         <span>タグで絞り込み</span>
+                        <span class="filter-count-badge" id="filter-count-badge" aria-live="polite" aria-atomic="true"></span>
                     </button>
                 </div>
                 <div class="content-count">
@@ -256,7 +275,7 @@
         <div id="panel-hotels" class="tab-panel" role="tabpanel" aria-labelledby="tab-hotels" hidden>
             <div class="hotel-cards">
                 $for(hotel-stays)$
-                <div class="hotel-card" data-hotel-code="$hotel-code$" style="border-left-color: $hotel-color$; cursor: pointer;">
+                <div class="hotel-card" data-hotel-code="$hotel-code$" style="border-left-color: $hotel-color$; cursor: pointer;" role="button" tabindex="0" aria-label="$hotel-code$の宿泊履歴を表示">
                     <div class="hotel-header">
                         <span class="hotel-badge" style="background-color: $hotel-color$;">$hotel-code$</span>
                         <div class="hotel-title">

--- a/contents/scss/disney_experience_summary_only.scss
+++ b/contents/scss/disney_experience_summary_only.scss
@@ -283,13 +283,31 @@ $button-small-font-size-mobile: 0.65rem;
             gap: 0.5rem;
         }
 
-        // タイトル右端のメタ情報
+        // タイトル右端のメタ情報（バッジスタイル）
         .title-meta {
             font-size: 0.85rem;
             color: #083963;
 
             .updated-label {
                 font-weight: 500;
+            }
+        }
+
+        // 最終更新日バッジ
+        .badge-info {
+            background: linear-gradient(135deg, #3CAADF 0%, #2980b9 100%);
+            color: white;
+            padding: 0.4rem 0.8rem;
+            border-radius: 20px;
+            font-size: 0.8rem;
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+            display: inline-flex;
+            align-items: center;
+            gap: 0.3rem;
+            white-space: nowrap;
+
+            i {
+                font-size: 0.85rem;
             }
         }
 
@@ -590,6 +608,25 @@ $button-small-font-size-mobile: 0.65rem;
                 background-color: #3e8ed0 !important;
                 border-color: #3e8ed0 !important;
                 color: white !important;
+            }
+        }
+
+        // フィルター選択数バッジ
+        .filter-count-badge {
+            display: inline-block;
+            background: #ff3860;
+            color: white;
+            border-radius: 50%;
+            width: 1.5rem;
+            height: 1.5rem;
+            line-height: 1.5rem;
+            text-align: center;
+            font-size: 0.75rem;
+            margin-left: 0.5rem;
+            font-weight: bold;
+
+            &:empty {
+                display: none;
             }
         }
 
@@ -950,6 +987,18 @@ $button-small-font-size-mobile: 0.65rem;
                 svg {
                     max-width: 100%;
                     height: auto;
+
+                    // CirclePackingサークルのホバー効果
+                    circle.circle-node {
+                        cursor: pointer;
+                        transition: stroke 0.3s ease, stroke-width 0.3s ease, filter 0.3s ease;
+
+                        &:hover {
+                            stroke: #333;
+                            stroke-width: 3;
+                            filter: brightness(1.1);
+                        }
+                    }
                 }
             }
 
@@ -962,12 +1011,15 @@ $button-small-font-size-mobile: 0.65rem;
             }
         }
 
-        // タブパネルの表示/非表示制御
+        // タブパネルの表示/非表示制御（フェードイン/アウト付き）
         .tab-panel {
             display: none;  // デフォルトは非表示
+            opacity: 0;
+            transition: opacity 0.3s ease-in-out;
 
             &.is-active {
                 display: block;  // アクティブ時のみ表示
+                opacity: 1;
             }
         }
 
@@ -978,6 +1030,22 @@ $button-small-font-size-mobile: 0.65rem;
             ul {
                 justify-content: flex-start;  // タブを左寄せ
                 border-bottom-color: rgba(8, 57, 99, 0.2);  // 既存カラーに合わせる
+                overflow-x: auto;
+                -webkit-overflow-scrolling: touch;
+
+                // 横スクロール時のスクロールバー
+                &::-webkit-scrollbar {
+                    height: 4px;
+                }
+
+                &::-webkit-scrollbar-track {
+                    background: rgba(8, 57, 99, 0.1);
+                }
+
+                &::-webkit-scrollbar-thumb {
+                    background: rgba(8, 57, 99, 0.3);
+                    border-radius: 2px;
+                }
             }
 
             li {
@@ -985,10 +1053,32 @@ $button-small-font-size-mobile: 0.65rem;
                     color: #6b7280;  // 非アクティブ時の色
                     border-bottom-color: transparent;
                     transition: color 0.3s ease, border-bottom-color 0.3s ease;
+                    display: flex;
+                    flex-direction: column;
+                    align-items: center;
 
                     &:hover {
                         color: #083963;
                         border-bottom-color: rgba(8, 57, 99, 0.3);
+                    }
+
+                    // タブラベルのスタイル
+                    .tab-label {
+                        display: flex;
+                        flex-direction: column;
+                        align-items: center;
+
+                        .tab-label-main {
+                            display: block;
+                        }
+
+                        .tab-label-desc {
+                            display: block;
+                            font-size: 0.65rem;
+                            opacity: 0.7;
+                            margin-top: 0.2rem;
+                            white-space: nowrap;
+                        }
                     }
                 }
 
@@ -996,6 +1086,8 @@ $button-small-font-size-mobile: 0.65rem;
                     color: #083963;  // アクティブ時は濃紺
                     border-bottom-color: #3CAADF;  // アクティブ時は水色
                     font-weight: 600;
+                    transform: translateY(-2px);
+                    transition: transform 0.2s ease, color 0.3s ease, border-bottom-color 0.3s ease;
                 }
             }
 
@@ -1012,6 +1104,18 @@ $button-small-font-size-mobile: 0.65rem;
             li a:focus-visible {
                 outline: 2px solid #3CAADF;
                 outline-offset: 2px;
+            }
+        }
+
+        // モバイルでのタブ最適化
+        @media (max-width: 768px) {
+            .tabs li a {
+                font-size: 0.8rem;
+                padding: 0.4em 0.6em;
+
+                .tab-label-desc {
+                    font-size: 0.6rem;
+                }
             }
         }
     }
@@ -1142,10 +1246,36 @@ $button-small-font-size-mobile: 0.65rem;
             border-left: 4px solid;
             box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
             transition: transform 0.3s ease, box-shadow 0.3s ease;
-            
+            position: relative;
+            cursor: pointer;
+
+            // クリック可能を示す視覚的ヒント
+            &::after {
+                content: "\f044";  // Font Awesome 'fa-edit' アイコン
+                font-family: "Font Awesome 6 Free";
+                font-weight: 900;
+                position: absolute;
+                top: 0.5rem;
+                right: 0.5rem;
+                opacity: 0.3;
+                font-size: 1rem;
+                color: #083963;
+                transition: opacity 0.3s ease;
+            }
+
             &:hover {
-                transform: translateY(-3px);
-                box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
+                transform: translateY(-5px) scale(1.02);
+                box-shadow: 0 6px 20px rgba(0, 0, 0, 0.15);
+
+                &::after {
+                    opacity: 0.6;
+                }
+            }
+
+            // アクセシビリティ: フォーカス時も同様の効果
+            &:focus-visible {
+                outline: 3px solid #3e8ed0;
+                outline-offset: 3px;
             }
             
             .hotel-header {

--- a/contents/ts/disney-hotel-card-navigation.ts
+++ b/contents/ts/disney-hotel-card-navigation.ts
@@ -33,5 +33,14 @@ export function initHotelCardNavigation(): void {
             const listTab = document.querySelector('[aria-controls="panel-list"]') as HTMLElement;
             listTab?.click();
         });
+
+        // キーボード操作対応
+        card.addEventListener("keydown", (event) => {
+            const keyboardEvent = event as KeyboardEvent;
+            if (keyboardEvent.key === "Enter" || keyboardEvent.key === " ") {
+                keyboardEvent.preventDefault();
+                (card as HTMLElement).click();
+            }
+        });
     });
 }

--- a/contents/ts/disney-tag-filter.ts
+++ b/contents/ts/disney-tag-filter.ts
@@ -705,6 +705,20 @@ if (typeof document !== "undefined") {
             updateSelectedTagsDisplay();
         };
 
+        // フィルターバッジを更新する関数
+        const updateFilterBadge = (): void => {
+            const badge: HTMLElement | null = document.getElementById("filter-count-badge");
+            if (!badge) return;
+
+            const count: number = selectedTags.size;
+            badge.textContent = count > 0 ? count.toString() : "";
+            // スクリーンリーダー向けのラベル更新
+            badge.setAttribute(
+                "aria-label",
+                count > 0 ? `${count}件のタグが選択されています` : "タグは選択されていません"
+            );
+        };
+
         // 選択されたタグの表示を更新する関数
         const updateSelectedTagsDisplay = (): void => {
             if (!selectedTagsContainer || !selectedTagsList) return;
@@ -725,6 +739,9 @@ if (typeof document !== "undefined") {
                     .join("");
                 selectedTagsList.innerHTML = tagButtons;
             }
+
+            // フィルターバッジも更新
+            updateFilterBadge();
         };
 
         // ログエントリのフィルタリング関数
@@ -789,17 +806,22 @@ if (typeof document !== "undefined") {
                 (entry: Element): boolean => !entry.classList.contains("filtered-out"),
             );
 
+            // パフォーマンス最適化: 最大遅延時間を500msに制限
+            const MAX_DELAY_MS = 500;
+            const delayPerItem = Math.min(50, MAX_DELAY_MS / Math.max(visibleEntries.length, 1));
+
             visibleEntries.forEach((entry: Element, index: number) => {
                 const htmlEntry = entry as HTMLElement;
                 htmlEntry.style.opacity = "0";
-                htmlEntry.style.transform = "translateY(20px)";
+                // GPU最適化: translate3dを使用してハードウェアアクセラレーションを有効化
+                htmlEntry.style.transform = "translate3d(0, 20px, 0)";
 
                 requestAnimationFrame(() => {
                     setTimeout((): void => {
                         htmlEntry.style.transition = "opacity 0.3s ease, transform 0.3s ease";
                         htmlEntry.style.opacity = "1";
-                        htmlEntry.style.transform = "translateY(0)";
-                    }, index * 50);
+                        htmlEntry.style.transform = "translate3d(0, 0, 0)";
+                    }, index * delayPerItem);
                 });
             });
         };


### PR DESCRIPTION
- **feat(disney): D3.js可視化機能を実装（タイムラインヒートマップとサークルパッキング）**
- **Restyled by stylish-haskell**
- **modified CLAUDE.md**
- **fix(disney): TypeScriptのexportsエラーとHaskell warningを修正**
- **chore(build): Viteバンドラーを導入してexportsエラーを解決**
- **fix(disney): code-review指摘事項の修正（型定義整合・年度選択有効化・メモリリーク対策）**
- **feat(disney): タイムラインヒートマップの年度全体表示機能を実装**
- **fix(disney): JSONデータ読み込みパスを相対パスに修正して404エラーを解消**
- **fix(disney): ヒートマップ表示範囲問題を解決（ViewBox + 横スクロール対応）**
- **fix(disney): SVG幅を動的計算してヒートマップ全体を完全表示**
- **feat(disney): 可視化をBulma Tabsで統合してタブ切り替えUIを実装**
- **fix(disney): 初期状態でヒートマップが表示されない問題を修正**
- **fix(disney): SVG height属性のD3.jsエラーを修正**
- **fix(disney): タブを左寄せに修正**
- **fix(disney): タブの左寄せ問題を完全修正（モバイル対応）**
- **feat(disney): 体験歴と体験データ可視化を3タブ統合UIに再構築**
- **fix(disney): タイトル変更とボタン状態管理・レイアウト修正**
- **fix(disney): フィルターボタンのaria-expanded="false"時の白色化を根本修正**
- **fix(disney): 統計情報の余白を狭く調整**
- **3 tabs**
- **refactor(disney): 統計情報の配置を最適化（タイトル行/ボタン行に分離）**
- **feat(disney): 統計情報フォントカラー調整と宿泊概算を4つ目のタブに統合**
- **fix(disney): 宿泊概算タブのスタイル崩れを修正**
- **feat(disney): URLハッシュによるタブ直リンク機能を実装**
- **feat(disney): タブ名変更とホテルカードクリック連携機能を実装**
- **feat(disney): CirclePackingサークルクリックでタグフィルタリング連携を実装**
- **feat(disney): CirclePacking色統一とHeatmapセルクリックナビゲーションを実装**
- **feat(disney): UX改善6項目を実装（高優先度＋モバイル最適化）**
