### PR TITLE
ci: Claude Codeレビューの追跡コメントを安定化

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          fetch-depth: 0
 
       - name: Run Claude Code Review
         id: claude-review
@@ -55,9 +55,12 @@ jobs:
             すべてのコメントは日本語で記述し、フィードバックは建設的かつ有益なものにせよ。
             この環境は non-interactive なので質問/確認をユーザーにすることはできない。
             できる限りの推論力を持ってレビュータスクを最後まで遂行せよ
+            指摘事項（修正提案を伴うもの）がある場合は、必ず mcp__github_inline_comment__create_inline_comment を使って該当行に投稿せよ。
+            行番号を特定できない指摘は投稿しないこと（推測での投稿は禁止）。
 
-          # Optional: Use sticky comments to make Claude reuse the same comment on subsequent pushes to the same PR
-          # use_sticky_comment: true
+          # 同一PRでコメントを増やさずに追跡コメントを更新する
+          use_sticky_comment: "true"
+          track_progress: "true"
           
           # Optional: Customize review based on file types
           # prompt: |


### PR DESCRIPTION
## 概要
- actions/checkout の `fetch-depth` を `0` に変更
- Claude Code Action の prompt にインラインコメント投稿条件を追記
- `use_sticky_comment: "true"` を有効化
- `track_progress: "true"` を有効化

## 背景
- Bot PR のレビューコメントが付いたり付かなかったりする不安定性を緩和するため
- 既に別プロジェクト（snipe-it）で効果確認済みの修正を同等適用

## 動作確認
- `make format`
- `make check`
- `make test`
