### PR TITLE
Add minimal Claude-based Dependabot auto-approve workflow

### DIFF
--- a/.github/workflows/dependabot-auto-approve.yml
+++ b/.github/workflows/dependabot-auto-approve.yml
@@ -1,26 +1,11 @@
 name: Dependabot Auto Approve
 
 on:
-  workflow_run:
-    workflows:
-      - CI-pr
-      - CI-lint-test
-      - CI-CodeQL
-      - CI-Restyled
-    types:
-      - completed
-  schedule:
-    - cron: "*/15 * * * *"
   workflow_dispatch:
 
 jobs:
   collect-target-prs:
-    if: >-
-      github.repository == 'falgon/roki-web' &&
-      (
-        github.event_name != 'workflow_run' ||
-        github.event.workflow_run.conclusion == 'success'
-      )
+    if: github.repository == 'falgon/roki-web'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/dependabot-claude-auto-approve.yml
+++ b/.github/workflows/dependabot-claude-auto-approve.yml
@@ -1,0 +1,352 @@
+name: Dependabot Claude Auto Approve
+
+on:
+  workflow_run:
+    workflows:
+      - CI-pr
+      - CI-lint-test
+      - CI-CodeQL
+      - CI-Restyled
+    types:
+      - completed
+  schedule:
+    - cron: "*/15 * * * *"
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "Optional pull request number to review manually"
+        required: false
+        type: string
+
+jobs:
+  collect-target-prs:
+    if: >-
+      github.repository == 'falgon/roki-web' &&
+      (
+        github.event_name != 'workflow_run' ||
+        github.event.workflow_run.conclusion == 'success'
+      )
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      pr-numbers: ${{ steps.collect.outputs.pr-numbers }}
+    env:
+      MANUAL_PR_NUMBER: ${{ inputs.pr_number || '' }}
+    steps:
+      - name: Collect candidate pull requests
+        id: collect
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.DEPENDABOT_AUTO_APPROVE_READ_BRANCH_PROTECTION_TOKEN }}
+          retries: 3
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const manualPrNumber = (process.env.MANUAL_PR_NUMBER ?? "").trim();
+            const dependabotLogins = new Set(["app/dependabot", "dependabot[bot]"]);
+
+            const setPullRequests = (numbers) => {
+              core.setOutput(
+                "pr-numbers",
+                JSON.stringify([...new Set(numbers)].sort((a, b) => a - b)),
+              );
+            };
+
+            if (manualPrNumber) {
+              if (!/^\d+$/.test(manualPrNumber)) {
+                throw new Error(`Invalid pr_number input: ${manualPrNumber}`);
+              }
+
+              return setPullRequests([Number(manualPrNumber)]);
+            }
+
+            if (context.eventName === "workflow_run") {
+              if (context.payload.workflow_run.event !== "pull_request") {
+                return setPullRequests([]);
+              }
+
+              return setPullRequests(
+                (context.payload.workflow_run.pull_requests ?? []).map(({ number }) => number),
+              );
+            }
+
+            const pullRequests = await github.paginate(github.rest.pulls.list, {
+              owner,
+              repo,
+              state: "open",
+              base: "develop",
+              per_page: 100,
+            });
+
+            return setPullRequests(
+              pullRequests
+                .filter(
+                  (pullRequest) =>
+                    dependabotLogins.has(String(pullRequest.user?.login ?? "")) &&
+                    pullRequest.labels.some(({ name }) => name === "automerge"),
+                )
+                .map(({ number }) => number),
+            );
+
+  review-and-approve:
+    needs: collect-target-prs
+    if: >-
+      github.repository == 'falgon/roki-web' &&
+      needs.collect-target-prs.outputs.pr-numbers != '[]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    strategy:
+      fail-fast: false
+      matrix:
+        pr-number: ${{ fromJson(needs.collect-target-prs.outputs.pr-numbers) }}
+    steps:
+      - name: Load pull request context
+        id: load-pr
+        uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ matrix.pr-number }}
+        with:
+          github-token: ${{ secrets.DEPENDABOT_AUTO_APPROVE_READ_BRANCH_PROTECTION_TOKEN }}
+          retries: 3
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const pullNumber = Number(process.env.PR_NUMBER);
+            const dependabotLogins = new Set(["app/dependabot", "dependabot[bot]"]);
+
+            const skip = (reason) => {
+              core.info(reason);
+              core.setOutput("skip", "true");
+              core.setOutput("skip-reason", reason);
+            };
+
+            const { data: pr } = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: pullNumber,
+            });
+
+            if (pr.state !== "open") {
+              return skip(`PR #${pullNumber} is not open.`);
+            }
+
+            if (!dependabotLogins.has(String(pr.user?.login ?? ""))) {
+              return skip(`PR #${pullNumber} is not authored by Dependabot.`);
+            }
+
+            if (String(pr.base?.ref ?? "") !== "develop") {
+              return skip(`PR #${pullNumber} does not target develop.`);
+            }
+
+            if (!pr.labels.some(({ name }) => name === "automerge")) {
+              return skip(`PR #${pullNumber} does not have the automerge label.`);
+            }
+
+            const reviewDecisionResult = await github.graphql(
+              `
+                query($owner: String!, $repo: String!, $pullNumber: Int!) {
+                  repository(owner: $owner, name: $repo) {
+                    pullRequest(number: $pullNumber) {
+                      reviewDecision
+                    }
+                  }
+                }
+              `,
+              {
+                owner,
+                repo,
+                pullNumber,
+              },
+            );
+
+            if (
+              reviewDecisionResult.repository?.pullRequest?.reviewDecision === "APPROVED"
+            ) {
+              return skip(`PR #${pullNumber} is already approved.`);
+            }
+
+            if ((pr.mergeable ?? null) !== true && pr.mergeable_state !== "clean") {
+              return skip(`PR #${pullNumber} is not currently mergeable.`);
+            }
+
+            core.setOutput("skip", "false");
+            core.setOutput("skip-reason", "");
+            core.setOutput("pr-number", String(pr.number));
+            core.setOutput("pr-url", pr.html_url);
+            core.setOutput("pr-title", pr.title);
+            core.setOutput("head-sha", pr.head.sha);
+
+      - name: Checkout repository
+        if: steps.load-pr.outputs.skip != 'true'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.load-pr.outputs.head-sha }}
+          fetch-depth: 0
+
+      - name: Run Claude review
+        id: review
+        if: steps.load-pr.outputs.skip != 'true'
+        continue-on-error: true
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.DEPENDABOT_AUTO_APPROVE_READ_BRANCH_PROTECTION_TOKEN }}
+          allowed_bots: "app/dependabot,dependabot,claude,kodiakhq"
+          claude_args: |
+            --model 'haiku'
+            --allowedTools Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr checks:*)
+            --json-schema '{"type":"object","additionalProperties":false,"required":["approve","summary","reason"],"properties":{"approve":{"type":"boolean"},"summary":{"type":"string","minLength":1},"reason":{"type":"string","minLength":1}}}'
+          prompt: |
+            Pull request number: ${{ steps.load-pr.outputs.pr-number }}
+            Pull request URL: ${{ steps.load-pr.outputs.pr-url }}
+            Pull request title: ${{ steps.load-pr.outputs.pr-title }}
+            Head SHA: ${{ steps.load-pr.outputs.head-sha }}
+
+            あなたは Dependabot PR を approve してよいかを判定する reviewer です。
+            すべて日本語で判断し、structured output だけを返してください。
+
+            必ず `gh pr view`、`gh pr diff`、必要に応じて `gh pr checks` を使って現在の PR 状態を確認してください。
+            `approve` を true にしてよいのは、少なくとも次をすべて満たす場合だけです:
+            - PR は Dependabot による dependency update で、差分に無関係な変更が見当たらない
+            - PR は develop 向けで、automerge ラベルが付いたままである
+            - 現在 mergeable である
+            - 現在の status checks に failing / pending がない
+            - 人手レビューなしで approve して問題ないと合理的に説明できる
+
+            ただし、現在実行中の `Dependabot Claude Auto Approve` 自身の check が pending であることは無視してください。
+
+            少しでも不確実なら `approve` は false にしてください。
+            `summary` は 1-2 文で簡潔に、`reason` は approve / 見送りの根拠を日本語で具体的に書いてください。
+
+      - name: Parse Claude review result
+        id: review-output
+        if: >-
+          always() &&
+          steps.load-pr.outcome == 'success' &&
+          steps.load-pr.outputs.skip != 'true'
+        env:
+          REVIEW_OUTCOME: ${{ steps.review.outcome }}
+          STRUCTURED_OUTPUT: ${{ steps.review.outputs.structured_output || '' }}
+        run: |
+          write_github_output_multiline() {
+            local key="$1"
+            local value="$2"
+            local delimiter
+
+            delimiter="$(uuidgen)"
+            while grep -Fqx "$delimiter" <<<"$value"; do
+              delimiter="$(uuidgen)"
+            done
+
+            {
+              echo "$key<<$delimiter"
+              printf '%s\n' "$value"
+              echo "$delimiter"
+            } >> "$GITHUB_OUTPUT"
+          }
+
+          if [[ "$REVIEW_OUTCOME" != "success" ]]; then
+            {
+              echo "valid=false"
+              echo "approve=false"
+            } >> "$GITHUB_OUTPUT"
+            write_github_output_multiline "summary" "Claude review step did not complete successfully."
+            write_github_output_multiline "reason" "Claude review outcome: $REVIEW_OUTCOME"
+            exit 0
+          fi
+
+          if ! jq -e '
+            type == "object" and
+            (.approve | type == "boolean") and
+            (.summary | type == "string" and length > 0) and
+            (.reason | type == "string" and length > 0)
+          ' <<<"$STRUCTURED_OUTPUT" >/dev/null; then
+            {
+              echo "valid=false"
+              echo "approve=false"
+            } >> "$GITHUB_OUTPUT"
+            write_github_output_multiline "summary" "Claude review output was invalid."
+            write_github_output_multiline "reason" "structured_output could not be parsed."
+            exit 0
+          fi
+
+          {
+            echo "valid=true"
+            echo "approve=$(jq -r '.approve' <<<"$STRUCTURED_OUTPUT")"
+          } >> "$GITHUB_OUTPUT"
+          write_github_output_multiline "summary" "$(jq -r '.summary' <<<"$STRUCTURED_OUTPUT")"
+          write_github_output_multiline "reason" "$(jq -r '.reason' <<<"$STRUCTURED_OUTPUT")"
+
+      - name: Revalidate pull request head
+        id: revalidate-head
+        if: >-
+          steps.review-output.outputs.valid == 'true' &&
+          steps.review-output.outputs.approve == 'true'
+        uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ steps.load-pr.outputs.pr-number }}
+          REVIEWED_HEAD_SHA: ${{ steps.load-pr.outputs.head-sha }}
+        with:
+          github-token: ${{ secrets.DEPENDABOT_AUTO_APPROVE_READ_BRANCH_PROTECTION_TOKEN }}
+          retries: 3
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const pullNumber = Number(process.env.PR_NUMBER);
+            const reviewedHeadSha = process.env.REVIEWED_HEAD_SHA;
+
+            const { data: pr } = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: pullNumber,
+            });
+
+            if (pr.head.sha !== reviewedHeadSha) {
+              core.info(
+                `PR #${pullNumber} head changed from ${reviewedHeadSha} to ${pr.head.sha}.`,
+              );
+              core.setOutput("matches", "false");
+              core.setOutput(
+                "reason",
+                `PR #${pullNumber} の head がレビュー後に ${reviewedHeadSha} から ${pr.head.sha} へ変わったため、承認を見送りました。`,
+              );
+              return;
+            }
+
+            core.setOutput("matches", "true");
+            core.setOutput("reason", "");
+
+      - name: Approve pull request
+        if: >-
+          steps.review-output.outputs.valid == 'true' &&
+          steps.review-output.outputs.approve == 'true' &&
+          steps.revalidate-head.outputs.matches == 'true'
+        env:
+          PR_URL: ${{ steps.load-pr.outputs.pr-url }}
+          REVIEW_SUMMARY: ${{ steps.review-output.outputs.summary }}
+          REVIEW_REASON: ${{ steps.review-output.outputs.reason }}
+          KIIROTORI_GH_CONFIG_HOSTS: ${{ secrets.KIIROTORI_GH_CONFIG_HOSTS }}
+          KIIROTORI_GH_CONFIG_CONFIG: ${{ secrets.KIIROTORI_GH_CONFIG_CONFIG }}
+        run: |
+          export GH_CONFIG_DIR="$PWD/.config"
+          mkdir -p "$GH_CONFIG_DIR"
+          printf '%s' "$KIIROTORI_GH_CONFIG_HOSTS" > "$GH_CONFIG_DIR/hosts.yml"
+          printf '%s' "$KIIROTORI_GH_CONFIG_CONFIG" > "$GH_CONFIG_DIR/config.yml"
+          REVIEW_BODY="$REVIEW_SUMMARY"$'\n\n'"$REVIEW_REASON"
+          gh pr review "$PR_URL" --approve --body "$REVIEW_BODY"
+
+      - name: Summarize decision
+        if: always()
+        run: |
+          {
+            echo "## Dependabot Claude auto-approve"
+            echo
+            echo "* Pull request: #${{ steps.load-pr.outputs.pr-number || matrix.pr-number || 'N/A' }}"
+            echo "* Candidate: \`${{ steps.load-pr.outputs.skip != 'true' && 'true' || 'false' }}\`"
+            echo "* Approved: \`${{ steps.review-output.outputs.approve || 'false' }}\`"
+            echo "* Summary: ${{ steps.review-output.outputs.summary || steps.load-pr.outputs.skip-reason || 'No evaluation result.' }}"
+            echo "* Reason: ${{ steps.revalidate-head.outputs.reason || steps.review-output.outputs.reason || 'No review reason.' }}"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- add a new Claude-based Dependabot auto-approve workflow
- keep the legacy workflow as manual-only fallback so Claude is the automatic approval path
- preserve safety with periodic rescans, review-decision checks, and head SHA revalidation

## Validation
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/dependabot-auto-approve.yml"); YAML.load_file(".github/workflows/dependabot-claude-auto-approve.yml")'
- make check
- npm test

## Review
- external reviewer-mini found and I fixed the periodic rescan/manual input issues
- a second reviewer-mini run did not return a final verdict after extended waiting