### PR TITLE
fix: stabilize page insight polling workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -153,6 +153,7 @@ jobs:
       with:
         submodules: false
     - name: Polling until deployed
+      id: set-result
       env:
         POLLING_MAX: 10
         POLLING_DURATION_MILLISECONDS: 5000
@@ -161,25 +162,30 @@ jobs:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         result-encoding: string
         script: |
-          let c = 0;
-          let res = false;
-          const it = setInterval(async () => {
-            const r = await github.repos.getLatestPagesBuild({
+          const maxAttempts = Number(process.env.POLLING_MAX);
+          const intervalMilliseconds = Number(process.env.POLLING_DURATION_MILLISECONDS);
+          const sleep = (milliseconds) =>
+            new Promise((resolve) => setTimeout(resolve, milliseconds));
+
+          for (let attempt = 0; attempt <= maxAttempts; attempt++) {
+            const r = await github.rest.repos.getLatestPagesBuild({
               owner: context.repo.owner,
               repo: context.repo.repo
             });
+
+            core.info(`GitHub Pages build status: ${r.data.status}`);
             if (r.data.status === "built") {
-              res = true;
-              clearInterval(it);
-            } else if (c > ${{ env.POLLING_MAX }}) {
-              res = false;
-              clearInterval(it);
+              return "true";
             }
-            ++c;
-          }, ${{ env.POLLING_DURATION_MILLISECONDS }});
-          return res.toString();
+
+            if (attempt < maxAttempts) {
+              await sleep(intervalMilliseconds);
+            }
+          }
+
+          return "false";
     - name: Get page insights
-      if: ${{ steps.set-result.outputs.result }} == "true"
+      if: ${{ steps.set-result.outputs.result == 'true' }}
       env:
         SP_THRESHOLD: 65
         PC_THRESHOLD: 90


### PR DESCRIPTION
## Summary
- fix the `page-insight` polling step to await GitHub Pages status checks instead of using an unawaited async `setInterval`
- add the missing `set-result` step id used by the PageSpeed condition
- wrap the PageSpeed condition in a single GitHub Actions expression to remove the annotation warning

## Investigation
The referenced job is still in progress, so `gh run view --job ... --log` cannot fetch logs yet. The public Actions page exposes an annotation for `.github/workflows/build.yml` line 182: the `if` condition mixed an expression token with literal text and always evaluated truthy. The surrounding polling script also returned before the async interval completed and could surface unhandled async errors.

## Verification
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/build.yml"); puts "YAML OK"'`\n- `git diff --check -- .github/workflows/build.yml`\n