### PR TITLE
fix: stabilize page insight polling on master

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -153,6 +153,7 @@ jobs:
       with:
         submodules: false
     - name: Polling until deployed
+      id: set-result
       env:
         POLLING_MAX: 10
         POLLING_DURATION_MILLISECONDS: 5000
@@ -161,25 +162,30 @@ jobs:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         result-encoding: string
         script: |
-          let c = 0;
-          let res = false;
-          const it = setInterval(async () => {
-            const r = await github.repos.getLatestPagesBuild({
+          const maxAttempts = Number(process.env.POLLING_MAX);
+          const intervalMilliseconds = Number(process.env.POLLING_DURATION_MILLISECONDS);
+          const sleep = (milliseconds) =>
+            new Promise((resolve) => setTimeout(resolve, milliseconds));
+
+          for (let attempt = 0; attempt <= maxAttempts; attempt++) {
+            const r = await github.rest.repos.getLatestPagesBuild({
               owner: context.repo.owner,
               repo: context.repo.repo
             });
+
+            core.info(`GitHub Pages build status: ${r.data.status}`);
             if (r.data.status === "built") {
-              res = true;
-              clearInterval(it);
-            } else if (c > ${{ env.POLLING_MAX }}) {
-              res = false;
-              clearInterval(it);
+              return "true";
             }
-            ++c;
-          }, ${{ env.POLLING_DURATION_MILLISECONDS }});
-          return res.toString();
+
+            if (attempt < maxAttempts) {
+              await sleep(intervalMilliseconds);
+            }
+          }
+
+          return "false";
     - name: Get page insights
-      if: ${{ steps.set-result.outputs.result }} == "true"
+      if: ${{ steps.set-result.outputs.result == 'true' }}
       env:
         SP_THRESHOLD: 65
         PC_THRESHOLD: 90


### PR DESCRIPTION
## Summary
- cherry-pick the page-insight polling fix from #1072 onto `master`
- add the missing `set-result` step id used by the PageSpeed condition
- replace the unawaited async `setInterval` polling with an awaited loop
- fix the `Get page insights` condition expression

## Why
PR #1072 is already merged into `develop`, but `master` is diverged and the production deploy workflow still runs from `master`. A full `develop -> master` merge would include many unrelated commits, so this PR carries only the workflow hotfix needed for the stuck `page-insight` job.

## Verification
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/build.yml"); puts "YAML OK"'`\n- `git diff --check HEAD~1..HEAD -- .github/workflows/build.yml`\n\nRefs: #1072\n