### PR TITLE
Fix Skicka Go version in PR CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ parameters:
 jobs:
   build:
     docker:
-    - image: cimg/go:1.25.0
+    - image: cimg/go:1.25.8
     resource_class: large
     environment:
       TZ: /usr/share/zoneinfo/Asia/Tokyo
@@ -32,7 +32,7 @@ jobs:
           echo 'export ARTIFACTS_GDRIVE_PATH="<< pipeline.parameters.GDRIVE_PATH >>"' >> $BASH_ENV
           source "$BASH_ENV"
     - restore_cache:
-        key: skicka-2026-02-26-go1.25.0
+        key: skicka-2026-02-26-go1.25.8
     - run:
         name: Setup tools
         command: |
@@ -46,7 +46,7 @@ jobs:
           fi
           curl -sSL https://get.haskellstack.org/ | sh
     - save_cache:
-        key: skicka-2026-02-26-go1.25.0
+        key: skicka-2026-02-26-go1.25.8
         paths:
           - ~/.go/bin
           - ~/.cache/go-build

--- a/.github/workflows/build_pr.yml
+++ b/.github/workflows/build_pr.yml
@@ -1,7 +1,7 @@
 name: CI-pr
 
 env:
-  GO_VERSION: 1.25.0
+  GO_VERSION: 1.25.8
   TZ: Asia/Tokyo
   DOCS_TARXZ: docs.tar.xz
 on:


### PR DESCRIPTION
## Summary

- Bump the CI-pr upload job Go version from 1.25.0 to 1.25.8.
- Bump the CircleCI Go image from cimg/go:1.25.0 to cimg/go:1.25.8.
- Update the CircleCI Skicka cache key suffix to match the Go patch version.

## Root cause

The CI-pr upload job installed Go 1.25.0 and then ran `go install github.com/google/skicka@latest`. The current dependency graph resolves `google.golang.org/api@v0.286.0`, which requires Go >= 1.25.8, so the install failed.

## Validation

- `curl -fsI https://dl.google.com/go/go1.25.8.linux-amd64.tar.gz`
- `docker manifest inspect cimg/go:1.25.8`
- `git diff --check`
- Ruby YAML parse for `.github/workflows/build_pr.yml` and `.circleci/config.yml`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -color=false -ignore 'shellcheck reported issue' .github/workflows/build_pr.yml`
- `make check` exits 0 with pre-existing explicit-any warnings
- `npm test` passes: 133 tests

## Notes

- `circleci` CLI is not installed in the local environment, so CircleCI validation was limited to YAML parsing and Docker image manifest verification.
- `claude-review-mcp` returned non-zero without useful stderr; reviewer subagents could not be re-spawned due thread limit.
