### PR TITLE
Fix flaky Disney tag filter debounce tests

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,29 +1,32 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.5.6/schema.json",
-  "vcs": {
-    "enabled": true,
-    "clientKind": "git",
-    "useIgnoreFile": true
-  },
-  "files": {
-    "ignoreUnknown": false
-  },
-  "formatter": {
-    "enabled": true,
-    "indentStyle": "space",
-    "indentWidth": 4,
-    "lineWidth": 100
-  },
-  "linter": {
-    "enabled": true,
-    "rules": {
-      "recommended": true
-    }
-  },
-  "javascript": {
+    "$schema": "https://biomejs.dev/schemas/2.5.6/schema.json",
+    "vcs": {
+        "enabled": true,
+        "clientKind": "git",
+        "useIgnoreFile": true
+    },
+    "files": {
+        "ignoreUnknown": false
+    },
     "formatter": {
-      "quoteStyle": "double",
-      "semicolons": "always"
+        "enabled": true,
+        "indentStyle": "space",
+        "indentWidth": 4,
+        "lineWidth": 100
+    },
+    "linter": {
+        "enabled": true,
+        "rules": {
+            "recommended": true,
+            "style": {
+                "noDoneCallback": "error"
+            }
+        }
+    },
+    "javascript": {
+        "formatter": {
+            "quoteStyle": "double",
+            "semicolons": "always"
+        }
     }
-  }
 }

--- a/contents/ts/__tests__/disney-tag-filter-search-input.test.ts
+++ b/contents/ts/__tests__/disney-tag-filter-search-input.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import "../disney-tag-filter";
+
+describe("Disney tag filter search input", () => {
+    const testWindow = window as typeof window & {
+        initializeSearchInput: (
+            searchInput: HTMLInputElement,
+            searchQueryRef: { value: string },
+            filterLogEntries: () => void,
+        ) => void;
+        searchDebounceDelayMs: number;
+    };
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        document.body.innerHTML = '<input type="text" id="search-input" />';
+    });
+
+    afterEach(() => {
+        vi.clearAllTimers();
+        vi.useRealTimers();
+    });
+
+    const initialize = (initialQuery = "") => {
+        const searchInput = document.getElementById("search-input") as HTMLInputElement;
+        const searchQueryRef = { value: initialQuery };
+        const filterLogEntries = vi.fn();
+        testWindow.initializeSearchInput(searchInput, searchQueryRef, filterLogEntries);
+
+        const input = (value: string) => {
+            searchInput.value = value;
+            searchInput.dispatchEvent(new Event("input", { bubbles: true }));
+        };
+
+        return { filterLogEntries, input, searchQueryRef };
+    };
+
+    it("filters a normal input after the debounce delay", () => {
+        const { filterLogEntries, input, searchQueryRef } = initialize();
+        input("disney");
+        expect(searchQueryRef.value).toBe("disney");
+
+        vi.advanceTimersByTime(testWindow.searchDebounceDelayMs - 1);
+        expect(filterLogEntries).not.toHaveBeenCalled();
+        vi.advanceTimersByTime(1);
+        expect(filterLogEntries).toHaveBeenCalledOnce();
+    });
+
+    it("only filters the last of multiple rapid inputs", () => {
+        const { filterLogEntries, input, searchQueryRef } = initialize();
+        for (const value of ["d", "di", "dis"]) {
+            input(value);
+            vi.advanceTimersByTime(50);
+        }
+        input("special");
+        expect(searchQueryRef.value).toBe("special");
+
+        vi.advanceTimersByTime(testWindow.searchDebounceDelayMs - 1);
+        expect(filterLogEntries).not.toHaveBeenCalled();
+        vi.advanceTimersByTime(1);
+        expect(filterLogEntries).toHaveBeenCalledOnce();
+    });
+
+    it("filters an empty input after the debounce delay", () => {
+        const { filterLogEntries, input, searchQueryRef } = initialize("disney");
+        input("");
+        expect(searchQueryRef.value).toBe("");
+
+        vi.advanceTimersByTime(testWindow.searchDebounceDelayMs - 1);
+        expect(filterLogEntries).not.toHaveBeenCalled();
+        vi.advanceTimersByTime(1);
+        expect(filterLogEntries).toHaveBeenCalledOnce();
+    });
+});

--- a/contents/ts/__tests__/disney-tag-filter.test.ts
+++ b/contents/ts/__tests__/disney-tag-filter.test.ts
@@ -397,58 +397,6 @@ describe("disney-tag-filter.ts", () => {
             `;
         });
 
-        it("should filter entries when user types in search input", (done) => {
-            const searchInput = document.getElementById("search-input") as HTMLInputElement;
-            const entries = document.querySelectorAll(".log-entry");
-
-            expect(searchInput).toBeTruthy();
-            expect(entries.length).toBe(3);
-
-            // 検索入力をシミュレート
-            searchInput.value = "disney";
-            const inputEvent = new Event("input", { bubbles: true });
-            searchInput.dispatchEvent(inputEvent);
-
-            // デバウンス処理を考慮して少し待機
-            setTimeout(() => {
-                // 検索が実行されたことを確認（この時点ではフィルタリングロジックがDOMContentLoaded内にあるため、
-                // 実際のフィルタリングは行われないが、イベントが正しく発火することを確認）
-                expect(searchInput.value).toBe("disney");
-                done();
-            }, 350); // デバウンス時間(300ms)より少し長く待機
-        });
-
-        it("should handle multiple rapid inputs with debounce", (done) => {
-            const searchInput = document.getElementById("search-input") as HTMLInputElement;
-
-            expect(searchInput).toBeTruthy();
-
-            // 複数の入力を素早く実行
-            searchInput.value = "d";
-            searchInput.dispatchEvent(new Event("input", { bubbles: true }));
-
-            setTimeout(() => {
-                searchInput.value = "di";
-                searchInput.dispatchEvent(new Event("input", { bubbles: true }));
-            }, 50);
-
-            setTimeout(() => {
-                searchInput.value = "dis";
-                searchInput.dispatchEvent(new Event("input", { bubbles: true }));
-            }, 100);
-
-            setTimeout(() => {
-                searchInput.value = "disney";
-                searchInput.dispatchEvent(new Event("input", { bubbles: true }));
-            }, 150);
-
-            // デバウンス処理により、最後の入力のみが処理されることを確認
-            setTimeout(() => {
-                expect(searchInput.value).toBe("disney");
-                done();
-            }, 500); // 全ての入力とデバウンス処理が完了するまで待機
-        });
-
         it("should normalize search queries correctly", () => {
             // 大文字小文字の正規化
             const query1 = normalizeString("DISNEY");
@@ -461,22 +409,6 @@ describe("disney-tag-filter.ts", () => {
             // 複合的な正規化
             const query3 = normalizeString("  TOKYO DisneySea  ");
             expect(query3).toBe("tokyo disneysea");
-        });
-
-        it("should handle empty search input", (done) => {
-            const searchInput = document.getElementById("search-input") as HTMLInputElement;
-
-            expect(searchInput).toBeTruthy();
-
-            // 空の入力をシミュレート
-            searchInput.value = "";
-            const inputEvent = new Event("input", { bubbles: true });
-            searchInput.dispatchEvent(inputEvent);
-
-            setTimeout(() => {
-                expect(searchInput.value).toBe("");
-                done();
-            }, 350);
         });
 
         it("should verify search input element exists", () => {

--- a/contents/ts/disney-tag-filter.ts
+++ b/contents/ts/disney-tag-filter.ts
@@ -1078,6 +1078,8 @@ const initializeClearButton = (
     });
 };
 
+const searchDebounceDelayMs = 300;
+
 // 検索入力のイベントハンドラーを初期化
 const initializeSearchInput = (
     searchInput: HTMLInputElement,
@@ -1099,7 +1101,7 @@ const initializeSearchInput = (
         searchDebounceTimer = setTimeout((): void => {
             filterLogEntries();
             searchDebounceTimer = null;
-        }, 300); // 300ms の遅延
+        }, searchDebounceDelayMs);
     });
 };
 
@@ -1122,6 +1124,14 @@ if (typeof window !== "undefined") {
             initializeLogImageSlideshows: typeof initializeLogImageSlideshows;
         }
     ).initializeLogImageSlideshows = initializeLogImageSlideshows;
+    (
+        window as typeof window & {
+            initializeSearchInput: typeof initializeSearchInput;
+            searchDebounceDelayMs: number;
+        }
+    ).initializeSearchInput = initializeSearchInput;
+    (window as typeof window & { searchDebounceDelayMs: number }).searchDebounceDelayMs =
+        searchDebounceDelayMs;
 }
 
 if (typeof document !== "undefined") {


### PR DESCRIPTION
## Summary

- replace Vitest 4-incompatible done-callback tests with deterministic fake-timer tests
- test normal, rapid, and empty search input debounce behavior directly
- add a Biome rule preventing done callbacks from being reintroduced

This addresses the unhandled timer callback that caused the `develop <- master` PR #1137 CI job to fail after the test suite had otherwise passed.

## Verification

- `make check`
- `npm run test:coverage` (141 tests)
- independent reviewer, security reviewer, and Claude review: zero findings