### PR TITLE
feat: derive Disney hotel stays from breakdown

### DIFF
--- a/contents/config/disney/Hotels.dhall
+++ b/contents/config/disney/Hotels.dhall
@@ -1,7 +1,9 @@
 -- 任意の深さのホテル詳細をChurchエンコードで表現する
 let HotelDetailF =
       λ(r : Type) →
-        < HDText : Text | HDNode : { hdLabel : Text, hdChildren : List r } >
+        < HDStay : { stayLabel : Text, stayCount : Natural }
+        | HDNode : { hdLabel : Text, hdChildren : List r }
+        >
 
 let HotelDetail = ∀(r : Type) → (HotelDetailF r → r) → r
 
@@ -33,29 +35,40 @@ let listConcat =
           (λ(xs : List a) → λ(acc : List a) → xs # acc)
           ([] : List a)
 
+let DetailRaw = { detailPathRaw : List Text, stayCountRaw : Natural }
+
 let prependToEach =
       λ(prefix : Text) →
-      λ(paths : List (List Text)) →
+      λ(details : List DetailRaw) →
         listMap
-          (List Text)
-          (List Text)
-          (λ(path : List Text) → [ prefix ] # path)
-          paths
+          DetailRaw
+          DetailRaw
+          ( λ(detail : DetailRaw) →
+              { detailPathRaw = [ prefix ] # detail.detailPathRaw
+              , stayCountRaw = detail.stayCountRaw
+              }
+          )
+          details
 
 let detailToPaths
-    : HotelDetail → List (List Text)
+    : HotelDetail → List DetailRaw
     = foldHotelDetail
-        (List (List Text))
-        ( λ(detailF : HotelDetailF (List (List Text))) →
+        (List DetailRaw)
+        ( λ(detailF : HotelDetailF (List DetailRaw)) →
             merge
-              { HDText = λ(text : Text) → [ [ text ] ]
+              { HDStay =
+                  λ(stay : { stayLabel : Text, stayCount : Natural }) →
+                    [ { detailPathRaw = [ stay.stayLabel ]
+                      , stayCountRaw = stay.stayCount
+                      }
+                    ]
               , HDNode =
                   λ ( node
-                    : { hdLabel : Text, hdChildren : List (List (List Text)) }
+                    : { hdLabel : Text, hdChildren : List (List DetailRaw) }
                     ) →
-                    let childPaths = listConcat (List Text) node.hdChildren
+                    let childDetails = listConcat DetailRaw node.hdChildren
 
-                    in  prependToEach node.hdLabel childPaths
+                    in  prependToEach node.hdLabel childDetails
               }
               detailF
         )
@@ -63,15 +76,16 @@ let detailToPaths
 let detailsToPaths =
       λ(details : List HotelDetail) →
         listConcat
-          (List Text)
-          (listMap HotelDetail (List (List Text)) detailToPaths details)
+          DetailRaw
+          (listMap HotelDetail (List DetailRaw) detailToPaths details)
 
-let makeText
-    : Text → HotelDetail
-    = λ(text : Text) →
+let makeStay
+    : Text → Natural → HotelDetail
+    = λ(label : Text) →
+      λ(count : Natural) →
       λ(r : Type) →
       λ(alg : HotelDetailF r → r) →
-        alg ((HotelDetailF r).HDText text)
+        alg ((HotelDetailF r).HDStay { stayLabel = label, stayCount = count })
 
 let makeNode
     : Text → List HotelDetail → HotelDetail
@@ -92,51 +106,46 @@ let makeNode
               )
 
 let Hotel =
-      { hotelCodeRaw : Text
-      , staysRaw : Natural
-      , detailsRaw : List (List Text)
-      , hotelColorRaw : Text
-      }
+      { hotelCodeRaw : Text, detailsRaw : List DetailRaw, hotelColorRaw : Text }
 
-in  [ { hotelCodeRaw = "FSH"
-      , staysRaw = 7
-      , detailsRaw =
-          detailsToPaths
-            [ makeNode
-                "ファンタジーシャトー"
-                [ makeNode "スプリングスサイド" [ makeText "バルアル" ]
-                , makeNode
-                    "ローズコートサイド"
-                    [ makeText "スーペリア ×3", makeText "スーペリア・アルコーヴ ×2" ]
-                , makeNode "べイエリアサイド" [ makeText "スーペリア・アルコーヴ" ]
-                ]
-            ]
-      , hotelColorRaw = "#854454"
-      }
-    , { hotelCodeRaw = "DHM"
-      , staysRaw = 5
-      , detailsRaw =
-          detailsToPaths
-            [ makeNode
-                "スイート"
-                [ makeText "ハバグラ", makeText "ハバテラ ×2", makeText "ピアバル" ]
-            , makeNode "ポルトパラディーゾ" [ makeText "スーペリアルームハーバービュー" ]
-            ]
-      , hotelColorRaw = "#8A7501"
-      }
-    , { hotelCodeRaw = "TDH"
-      , staysRaw = 6
-      , detailsRaw =
-          detailsToPaths
-            [ makeNode "キャラ" [ makeText "美女野獣", makeText "シンデレラ" ]
-            , makeNode "スーペリア" [ makeText "コーナールーム ×2", makeText "パークグランドビュー" ]
-            , makeNode "コンシェルジュ" [ makeText "バルコニールーム パークグランドビュー" ]
-            ]
-      , hotelColorRaw = "#B95C00"
-      }
-    , { hotelCodeRaw = "TSH"
-      , staysRaw = 3
-      , detailsRaw = detailsToPaths [ makeText "スタンダードルーム ×3" ]
-      , hotelColorRaw = "#C28A02"
-      }
-    ]
+in    [ { hotelCodeRaw = "FSH"
+        , detailsRaw =
+            detailsToPaths
+              [ makeNode
+                  "ファンタジーシャトー"
+                  [ makeNode "スプリングスサイド" [ makeStay "バルアル" 1 ]
+                  , makeNode
+                      "ローズコートサイド"
+                      [ makeStay "スーペリア" 3, makeStay "スーペリア・アルコーヴ" 2 ]
+                  , makeNode "べイエリアサイド" [ makeStay "スーペリア・アルコーヴ" 1 ]
+                  ]
+              ]
+        , hotelColorRaw = "#854454"
+        }
+      , { hotelCodeRaw = "DHM"
+        , detailsRaw =
+            detailsToPaths
+              [ makeNode
+                  "スイート"
+                  [ makeStay "ハバグラ" 1, makeStay "ハバテラ" 2, makeStay "ピアバル" 1 ]
+              , makeNode "ポルトパラディーゾ" [ makeStay "スーペリアルームハーバービュー" 1 ]
+              ]
+        , hotelColorRaw = "#8A7501"
+        }
+      , { hotelCodeRaw = "TDH"
+        , detailsRaw =
+            detailsToPaths
+              [ makeNode "キャラ" [ makeStay "美女野獣" 1, makeStay "シンデレラ" 1 ]
+              , makeNode
+                  "スーペリア"
+                  [ makeStay "コーナールーム" 2, makeStay "パークグランドビュー" 1 ]
+              , makeNode "コンシェルジュ" [ makeStay "バルコニールーム パークグランドビュー" 1 ]
+              ]
+        , hotelColorRaw = "#B95C00"
+        }
+      , { hotelCodeRaw = "TSH"
+        , detailsRaw = detailsToPaths [ makeStay "スタンダードルーム" 3 ]
+        , hotelColorRaw = "#C28A02"
+        }
+      ]
+    : List Hotel

--- a/roki-web.cabal
+++ b/roki-web.cabal
@@ -48,6 +48,7 @@ library
       Contexts.Utils
       Data.Disney.Experience
       Data.Disney.Experience.Generator
+      Data.Disney.HotelStay
       Hakyll.Web.Feed.Extra
       Media
       Media.JS
@@ -180,6 +181,7 @@ test-suite roki-web-test
       Config.TopPageSpec
       Data.Disney.Experience.GeneratorSpec
       Data.Disney.ExperienceSpec
+      Data.Disney.HotelStaySpec
       Hakyll.Web.Feed.ExtraSpec
       TestHelpers
       Utils.BaseSpec

--- a/src/Data/Disney/HotelStay.hs
+++ b/src/Data/Disney/HotelStay.hs
@@ -1,0 +1,271 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Data.Disney.HotelStay (
+    Hotel,
+    HotelConfigException (..),
+    HotelConfigError (..),
+    HotelDetail (..),
+    HotelRaw (..),
+    HotelStayRaw (..),
+    describeHotelConfigError,
+    details,
+    deriveHotels,
+    formatStayLabel,
+    hotelCode,
+    hotelColor,
+    hotelStayCount,
+    loadHotels,
+    productionHotelsPath,
+    renderHotelDetailsHtml,
+) where
+
+import           Control.Exception     (Exception (displayException), throwIO)
+import qualified Data.ByteString       as BS
+import           Data.Char             (isHexDigit, isSpace)
+import           Data.Foldable         (traverse_)
+import           Data.Functor.Identity (Identity (..))
+import           Data.List             (findIndex, foldl', intercalate,
+                                        isPrefixOf)
+import qualified Data.Text             as T
+import qualified Data.Text.Encoding    as TE
+import qualified Data.Text.Lazy        as TL
+import           Dhall                 (FromDhall, Generic, Natural, auto,
+                                        defaultInputSettings, inputWithSettings,
+                                        rootDirectory, sourceName)
+import qualified Lucid
+import           System.FilePath       (takeDirectory)
+
+data HotelDetail
+  = HDStay String Natural
+  | HDNode String [HotelDetail]
+  deriving (Eq, Show)
+
+data Hotel = Hotel String [HotelDetail] String
+  deriving (Eq, Show)
+
+hotelCode :: Hotel -> String
+hotelCode (Hotel code _ _) = code
+
+details :: Hotel -> [HotelDetail]
+details (Hotel _ hotelDetails _) = hotelDetails
+
+hotelColor :: Hotel -> String
+hotelColor (Hotel _ _ color) = color
+
+data HotelStayRaw = HotelStayRaw {
+    detailPathRaw :: [String]
+  , stayCountRaw  :: Natural
+  } deriving (Eq, Generic, Show)
+
+instance FromDhall HotelStayRaw
+
+data HotelRaw = HotelRaw {
+    hotelCodeRaw  :: String
+  , detailsRaw    :: [HotelStayRaw]
+  , hotelColorRaw :: String
+  } deriving (Eq, Generic, Show)
+
+instance FromDhall HotelRaw
+
+data HotelConfigError
+  = EmptyHotels
+  | EmptyHotelCode Int
+  | InvalidUtf8 String
+  | InvalidHotelCode String
+  | DuplicateHotelCode String
+  | InvalidHotelColor String String
+  | EmptyHotelDetails String
+  | EmptyDetailPath String
+  | EmptyDetailLabel String [String]
+  | ZeroStayCount String [String]
+  | DuplicateDetailPath String [String]
+  | ConflictingDetailPath String [String] [String]
+  deriving (Eq, Show)
+
+data HotelConfigException = HotelConfigException FilePath HotelConfigError
+  deriving (Eq)
+
+instance Show HotelConfigException where
+    show (HotelConfigException path configError) =
+        describeHotelConfigError path configError
+
+instance Exception HotelConfigException where
+    displayException (HotelConfigException path configError) =
+        describeHotelConfigError path configError
+
+productionHotelsPath :: FilePath
+productionHotelsPath = "contents/config/disney/Hotels.dhall"
+
+loadHotels :: FilePath -> IO [Hotel]
+loadHotels path = do
+    bytes <- BS.readFile path
+    source <- either (throwIO . HotelConfigException path . InvalidUtf8 . show) pure $
+        TE.decodeUtf8' bytes
+    rawHotels <- inputWithSettings settings auto source
+    either (throwIO . HotelConfigException path) pure $
+        deriveHotels rawHotels
+  where
+    settings =
+        set sourceName path $
+            set rootDirectory (takeDirectory path) defaultInputSettings
+
+    set lens value = runIdentity . lens (const $ Identity value)
+
+deriveHotels :: [HotelRaw] -> Either HotelConfigError [Hotel]
+deriveHotels [] = Left EmptyHotels
+deriveHotels rawHotels = do
+    validateHotelCodes $ map hotelCodeRaw rawHotels
+    traverse deriveHotel rawHotels
+
+validateHotelCodes :: [String] -> Either HotelConfigError ()
+validateHotelCodes codes
+    | Just index <- findIndex isBlank codes = Left $ EmptyHotelCode (index + 1)
+    | Just invalidCode <- firstInvalidHotelCode codes = Left $ InvalidHotelCode invalidCode
+    | otherwise = case firstDuplicate codes of
+        Just code -> Left $ DuplicateHotelCode code
+        Nothing   -> Right ()
+
+deriveHotel :: HotelRaw -> Either HotelConfigError Hotel
+deriveHotel rawHotel = do
+    validateHotelColor code $ hotelColorRaw rawHotel
+    validateStayDetails code rawDetails
+    pure $ Hotel code (buildHotelDetails rawDetails) (hotelColorRaw rawHotel)
+  where
+    code = hotelCodeRaw rawHotel
+    rawDetails = detailsRaw rawHotel
+
+validateStayDetails :: String -> [HotelStayRaw] -> Either HotelConfigError ()
+validateStayDetails code rawDetails
+    | null rawDetails = Left $ EmptyHotelDetails code
+    | otherwise = do
+        traverse_ validateDetail rawDetails
+        case firstDuplicate paths of
+            Just duplicatePath -> Left $ DuplicateDetailPath code duplicatePath
+            Nothing -> case firstPathConflict paths of
+                Just (shorterPath, longerPath) ->
+                    Left $ ConflictingDetailPath code shorterPath longerPath
+                Nothing -> Right ()
+  where
+    paths = map detailPathRaw rawDetails
+    validateDetail rawDetail
+        | null path = Left $ EmptyDetailPath code
+        | any isBlank path = Left $ EmptyDetailLabel code path
+        | stayCountRaw rawDetail == 0 = Left $ ZeroStayCount code path
+        | otherwise = Right ()
+      where
+        path = detailPathRaw rawDetail
+
+buildHotelDetails :: [HotelStayRaw] -> [HotelDetail]
+buildHotelDetails = foldl' (flip insertStayPath) []
+
+insertStayPath :: HotelStayRaw -> [HotelDetail] -> [HotelDetail]
+-- Empty paths are rejected by validateStayDetails before this internal builder runs.
+insertStayPath (HotelStayRaw [] _) forest = forest
+insertStayPath (HotelStayRaw [leaf] count) forest = insertStay leaf count forest
+insertStayPath (HotelStayRaw (label:rest) count) forest =
+    insertBranch label (HotelStayRaw rest count) forest
+
+insertStay :: String -> Natural -> [HotelDetail] -> [HotelDetail]
+insertStay label count []            = [HDStay label count]
+insertStay label count (detail:rest) = detail : insertStay label count rest
+
+insertBranch :: String -> HotelStayRaw -> [HotelDetail] -> [HotelDetail]
+insertBranch label rawDetail [] =
+    [HDNode label (insertStayPath rawDetail [])]
+insertBranch label rawDetail (HDNode nodeLabel children:rest)
+    | nodeLabel == label = HDNode label (insertStayPath rawDetail children) : rest
+insertBranch label rawDetail (detail:rest) =
+    detail : insertBranch label rawDetail rest
+
+hotelStayCount :: Hotel -> Natural
+hotelStayCount = sum . map detailStayCount . details
+  where
+    detailStayCount (HDStay _ count)    = count
+    detailStayCount (HDNode _ children) = sum $ map detailStayCount children
+
+formatStayLabel :: String -> Natural -> String
+formatStayLabel label 1     = label
+formatStayLabel label count = label ++ " ×" ++ show count
+
+describeHotelConfigError :: FilePath -> HotelConfigError -> String
+describeHotelConfigError path configError =
+    "Invalid hotel configuration in " ++ path ++ ": " ++ describe configError
+  where
+    describe EmptyHotels = "at least one hotel is required"
+    describe (EmptyHotelCode index) =
+        "hotel at index " ++ show index ++ " has an empty code"
+    describe (InvalidUtf8 reason) = "file is not valid UTF-8: " ++ reason
+    describe (InvalidHotelCode code) =
+        "hotel code must contain only A-Z, 0-9, '_' or '-': " ++ code
+    describe (DuplicateHotelCode code) = "duplicate hotel code: " ++ code
+    describe (InvalidHotelColor code color) =
+        "hotel " ++ code ++ " has an invalid #RRGGBB color: " ++ color
+    describe (EmptyHotelDetails code) = "hotel " ++ code ++ " has no stay details"
+    describe (EmptyDetailPath code) = "hotel " ++ code ++ " has an empty detail path"
+    describe (EmptyDetailLabel code detailPath) =
+        "hotel " ++ code ++ " has an empty label in path: " ++ displayPath detailPath
+    describe (ZeroStayCount code detailPath) =
+        "hotel " ++ code ++ " has zero stays at path: " ++ displayPath detailPath
+    describe (DuplicateDetailPath code detailPath) =
+        "hotel " ++ code ++ " has a duplicate path: " ++ displayPath detailPath
+    describe (ConflictingDetailPath code shorterPath longerPath) =
+        "hotel " ++ code ++ " has conflicting paths: "
+            ++ displayPath shorterPath
+            ++ " and "
+            ++ displayPath longerPath
+
+    displayPath = intercalate " > "
+
+renderHotelDetailsHtml :: [HotelDetail] -> String
+renderHotelDetailsHtml = concatMap (renderDetail 0)
+  where
+    renderDetail level (HDStay label count) =
+        renderSpan level $ formatStayLabel label count
+    renderDetail level (HDNode label children) =
+        renderSpan level label ++ concatMap (renderDetail (level + 1)) children
+
+    renderSpan level text =
+        let classLevel = min level 3
+            className = "hotel-detail-item hotel-detail-level-" ++ show classLevel
+        in TL.unpack $ Lucid.renderText $
+            Lucid.span_ [Lucid.class_ $ T.pack className] (Lucid.toHtml $ T.pack text)
+
+firstInvalidHotelCode :: [String] -> Maybe String
+firstInvalidHotelCode = firstMatch . filter (not . validHotelCode)
+  where
+    validHotelCode = all isAllowedCodeCharacter
+    isAllowedCodeCharacter character =
+        ('A' <= character && character <= 'Z')
+            || ('0' <= character && character <= '9')
+            || character == '_'
+            || character == '-'
+
+validateHotelColor :: String -> String -> Either HotelConfigError ()
+validateHotelColor code color = case color of
+    '#':hexDigits
+        | length hexDigits == 6 && all isHexDigit hexDigits -> Right ()
+    _ -> Left $ InvalidHotelColor code color
+
+firstDuplicate :: Eq a => [a] -> Maybe a
+firstDuplicate values = findDuplicate values []
+  where
+    findDuplicate [] _ = Nothing
+    findDuplicate (value:rest) seen
+        | value `elem` seen = Just value
+        | otherwise = findDuplicate rest (value : seen)
+
+firstPathConflict :: Eq a => [[a]] -> Maybe ([a], [a])
+firstPathConflict paths = firstMatch
+    [ (shorterPath, longerPath)
+    | shorterPath <- paths
+    , longerPath <- paths
+    , shorterPath /= longerPath
+    , shorterPath `isPrefixOf` longerPath
+    ]
+
+firstMatch :: [a] -> Maybe a
+firstMatch []      = Nothing
+firstMatch (x : _) = Just x
+
+isBlank :: String -> Bool
+isBlank = all isSpace

--- a/src/Rules/DisneyExperienceSummary.hs
+++ b/src/Rules/DisneyExperienceSummary.hs
@@ -8,17 +8,17 @@ import           Data.Aeson                       (encode)
 import qualified Data.ByteString.Lazy             as BL
 import           Data.Char                        (isDigit)
 import           Data.Disney.Experience.Generator
-import           Data.List                        (foldl', isPrefixOf,
-                                                   isSuffixOf, nub, sort,
-                                                   sortBy, sortOn)
+import           Data.Disney.HotelStay
+import           Data.List                        (isPrefixOf, isSuffixOf, nub,
+                                                   sort, sortBy, sortOn)
 import qualified Data.Map                         as M
 import           Data.Maybe                       (fromMaybe)
 import           Data.Ord                         (comparing)
 import           Data.String                      (IsString (..))
 import           Data.Time                        (defaultTimeLocale,
                                                    formatTime)
-import           Dhall                            (FromDhall, Generic, Natural,
-                                                   auto, input)
+import           Dhall                            (FromDhall, Generic, auto,
+                                                   input)
 import           Hakyll
 import           System.Directory                 (doesFileExist,
                                                    getModificationTime,
@@ -44,53 +44,6 @@ data Favorite = Favorite {
   } deriving (Generic, Show)
 
 instance FromDhall Favorite
-
--- ホテルの詳細情報の階層構造（任意階層対応）
-data HotelDetail
-  = HDText String
-  | HDNode { hdLabel :: String, hdChildren :: [HotelDetail] }
-  deriving (Generic, Show)
-
--- ホテル情報のデータ構造
-data Hotel = Hotel {
-    hotelCode  :: String
-  , stays      :: Natural
-  , details    :: [HotelDetail]
-  , hotelColor :: String
-  } deriving (Show)
-
--- Dhallから読み込むための中間データ構造
-data HotelRaw = HotelRaw {
-    hotelCodeRaw  :: String
-  , staysRaw      :: Natural
-  , detailsRaw    :: [[String]]
-  , hotelColorRaw :: String
-  } deriving (Generic, Show)
-
-instance FromDhall HotelRaw
-
-buildHotelDetails :: [[String]] -> [HotelDetail]
-buildHotelDetails = foldl' (flip insertPath) []
-
-insertPath :: [String] -> [HotelDetail] -> [HotelDetail]
-insertPath [] forest           = forest
-insertPath [leaf] forest       = insertLeaf leaf forest
-insertPath (label:rest) forest = insertBranch label rest forest
-
-insertLeaf :: String -> [HotelDetail] -> [HotelDetail]
-insertLeaf leaf [] = [HDText leaf]
-insertLeaf leaf (HDText txt : xs)
-    | txt == leaf = HDText txt : xs
-    | otherwise = HDText txt : insertLeaf leaf xs
-insertLeaf leaf (node@HDNode{} : xs) = node : insertLeaf leaf xs
-
-insertBranch :: String -> [String] -> [HotelDetail] -> [HotelDetail]
-insertBranch label rest [] =
-    [HDNode { hdLabel = label, hdChildren = insertPath rest [] }]
-insertBranch label rest (node@HDNode { hdLabel = lbl, hdChildren = chldn } : xs)
-    | lbl == label = HDNode lbl (insertPath rest chldn) : xs
-    | otherwise = node : insertBranch label rest xs
-insertBranch label rest (leaf@HDText{} : xs) = leaf : insertBranch label rest xs
 
 -- タグ設定のデータ構造
 data TagConfig = TagConfig {
@@ -211,21 +164,12 @@ loadDisneyFavorites = input auto "./contents/config/disney/Favorites.dhall"
 
 -- Dhallファイルからホテル情報を読み込み
 loadDisneyHotels :: IO [Hotel]
-loadDisneyHotels =
-    map convert <$> (input auto "./contents/config/disney/Hotels.dhall" :: IO [HotelRaw])
-  where
-    convert (HotelRaw codeRaw staysRaw detailPathsRaw colorRaw) =
-        Hotel
-            { hotelCode = codeRaw
-            , stays = staysRaw
-            , details = buildHotelDetails detailPathsRaw
-            , hotelColor = colorRaw
-            }
+loadDisneyHotels = loadHotels productionHotelsPath
 
 -- Hotels.dhallの最終更新日を取得
 getHotelsLastModified :: IO String
 getHotelsLastModified = do
-    modTime <- getModificationTime "./contents/config/disney/Hotels.dhall"
+    modTime <- getModificationTime productionHotelsPath
     return $ formatTime defaultTimeLocale "%Y/%m/%d" modTime
 
 -- ディズニーログの最終更新日を取得（最も新しいファイルの日付）
@@ -320,25 +264,11 @@ disneyLogCtx tagConfig = mconcat
 hotelCtx :: Context Hotel
 hotelCtx = mconcat
     [ field "hotel-code" (return . hotelCode . itemBody)
-    , field "stays-count" (return . show . stays . itemBody)
+    , field "stays-count" (return . show . hotelStayCount . itemBody)
     , field "hotel-color" (return . hotelColor . itemBody)
     , field "hotel-details-html" $ \item ->
-        return $ renderHotelDetails (details $ itemBody item)
+        return $ renderHotelDetailsHtml (details $ itemBody item)
     ]
-  where
-    -- 階層構造をHTMLに変換
-    renderHotelDetails :: [HotelDetail] -> String
-    renderHotelDetails = concatMap (renderDetail 0)
-
-    renderDetail :: Int -> HotelDetail -> String
-    renderDetail level (HDText text) = renderSpan level text
-    renderDetail level (HDNode {hdLabel = lbl, hdChildren = chldn}) =
-        renderSpan level lbl ++ concatMap (renderDetail (level + 1)) chldn
-
-    renderSpan :: Int -> String -> String
-    renderSpan level text =
-        let classLevel = min level 3
-        in "<span class=\"hotel-detail-item hotel-detail-level-" ++ show classLevel ++ "\">" ++ text ++ "</span>"
 
 rules :: PageConfReader Rules ()
 rules = do
@@ -379,7 +309,7 @@ rules = do
                     logsLastModified <- unsafeCompiler getLogsLastModified
                     tagConfig <- unsafeCompiler tagConfigMap
                     disneyLogs <- sortByNum <$> loadAllSnapshots disneyLogsPattern disneyExperienceSummarySnapshot
-                    let totalStays = sum $ map stays hotels
+                    let totalStays = sum $ map hotelStayCount hotels
                     let totalLogs = length disneyLogs
                     -- ユニークなタグリストを作成
                     uniqueTags <- do

--- a/test/Data/Disney/HotelStaySpec.hs
+++ b/test/Data/Disney/HotelStaySpec.hs
@@ -1,0 +1,303 @@
+module Data.Disney.HotelStaySpec (spec) where
+
+import           Control.Monad         (unless)
+import           Data.Disney.HotelStay
+import           Data.List             (sortOn)
+import           System.Directory      (doesFileExist)
+import           System.FilePath       ((</>))
+import           System.IO             (IOMode (WriteMode), hClose, hPutChar,
+                                        hPutStr, hSetBinaryMode, hSetEncoding,
+                                        utf8, withFile)
+import           System.IO.Temp        (withSystemTempDirectory,
+                                        withSystemTempFile)
+import           Test.Hspec
+
+spec :: Spec
+spec = do
+    describe "deriveHotels" $ do
+        it "derives a hotel's stay count from its structured breakdown" $ do
+            let rawHotel = HotelRaw
+                    { hotelCodeRaw = "FSH"
+                    , detailsRaw =
+                        [ HotelStayRaw ["ファンタジーシャトー", "ローズコートサイド", "スーペリア"] 3
+                        , HotelStayRaw ["ファンタジーシャトー", "ローズコートサイド", "スーペリア・アルコーヴ"] 2
+                        , HotelStayRaw ["ファンタジーシャトー", "べイエリアサイド", "スーペリア・アルコーヴ"] 1
+                        , HotelStayRaw ["ファンタジーシャトー", "スプリングスサイド", "バルアル"] 1
+                        ]
+                    , hotelColorRaw = "#854454"
+                    }
+
+            hotels <- expectRight $ deriveHotels [rawHotel]
+            map hotelStayCount hotels `shouldBe` [7]
+
+        it "preserves the configured hierarchy and insertion order" $ do
+            let rawHotel = HotelRaw
+                    { hotelCodeRaw = "DHM"
+                    , detailsRaw =
+                        [ HotelStayRaw ["スイート", "ハバグラ"] 1
+                        , HotelStayRaw ["スイート", "ハバテラ"] 2
+                        , HotelStayRaw ["ポルトパラディーゾ", "スーペリアルームハーバービュー"] 1
+                        ]
+                    , hotelColorRaw = "#8A7501"
+                    }
+
+            hotels <- expectRight $ deriveHotels [rawHotel]
+            map details hotels `shouldBe`
+                [ [ HDNode "スイート"
+                        [ HDStay "ハバグラ" 1
+                        , HDStay "ハバテラ" 2
+                        ]
+                  , HDNode "ポルトパラディーゾ"
+                        [HDStay "スーペリアルームハーバービュー" 1]
+                  ]
+                ]
+
+        it "keeps a branch at its first position when later paths revisit it" $ do
+            let rawHotel = hotelWith
+                    [ HotelStayRaw ["B", "first"] 1
+                    , HotelStayRaw ["A", "only"] 1
+                    , HotelStayRaw ["B", "second"] 1
+                    ]
+
+            hotels <- expectRight $ deriveHotels [rawHotel]
+            map details hotels `shouldBe`
+                [ [ HDNode "B" [HDStay "first" 1, HDStay "second" 1]
+                  , HDNode "A" [HDStay "only" 1]
+                  ]
+                ]
+
+        it "rejects invalid and ambiguous breakdowns" $ do
+            deriveHotels [hotelWith []]
+                `shouldBe` Left (EmptyHotelDetails "TDH")
+            deriveHotels [hotelWith [HotelStayRaw [] 1]]
+                `shouldBe` Left (EmptyDetailPath "TDH")
+            deriveHotels [hotelWith [HotelStayRaw [" "] 1]]
+                `shouldBe` Left (EmptyDetailLabel "TDH" [" "])
+            deriveHotels [hotelWith [HotelStayRaw ["スーペリア"] 0]]
+                `shouldBe` Left (ZeroStayCount "TDH" ["スーペリア"])
+            deriveHotels [hotelWith $ replicate 2 (HotelStayRaw ["スーペリア"] 1)]
+                `shouldBe` Left (DuplicateDetailPath "TDH" ["スーペリア"])
+            deriveHotels [hotelWith
+                [ HotelStayRaw ["スーペリア"] 1
+                , HotelStayRaw ["スーペリア", "コーナールーム"] 1
+                ]]
+                `shouldBe` Left
+                    (ConflictingDetailPath "TDH" ["スーペリア"] ["スーペリア", "コーナールーム"])
+
+        it "rejects empty and duplicate hotel codes" $ do
+            deriveHotels [] `shouldBe` Left EmptyHotels
+            deriveHotels [hotelWithCode ""] `shouldBe` Left (EmptyHotelCode 1)
+            deriveHotels [hotelWithCode "TDH", hotelWithCode "   "]
+                `shouldBe` Left (EmptyHotelCode 2)
+            deriveHotels [hotelWithCode "TDH\"><script>"]
+                `shouldBe` Left (InvalidHotelCode "TDH\"><script>")
+            deriveHotels [hotelWithCode "tdh"]
+                `shouldBe` Left (InvalidHotelCode "tdh")
+            deriveHotels [hotelWithCode "TDH", hotelWithCode "TDH"]
+                `shouldBe` Left (DuplicateHotelCode "TDH")
+
+        it "rejects colors that are unsafe for the generated style attribute" $ do
+            hotel <- expectSingleHotel $ deriveHotels [hotelWithColor "#abcdef"]
+            hotelColor hotel `shouldBe` "#abcdef"
+            mapM_ (\color ->
+                deriveHotels [hotelWithColor color]
+                    `shouldBe` Left (InvalidHotelColor "TDH" color))
+                [ "#FFF"
+                , "#1234567"
+                , "#GGGGGG"
+                , "B95C00"
+                , "red; background-image: url(javascript:alert(1))"
+                ]
+
+    describe "formatStayLabel" $ do
+        it "keeps single stays unchanged and appends the existing suffix for multiple stays" $ do
+            formatStayLabel "ハバグラ" 1 `shouldBe` "ハバグラ"
+            formatStayLabel "スーペリア" 3 `shouldBe` "スーペリア \x00D7\&3"
+
+    describe "describeHotelConfigError" $ do
+        it "includes the source path and readable detail path" $ do
+            describeHotelConfigError productionHotelsPath
+                (ZeroStayCount "TDH" ["スーペリア", "コーナールーム"])
+                `shouldBe`
+                    "Invalid hotel configuration in "
+                        ++ productionHotelsPath
+                        ++ ": hotel TDH has zero stays at path: スーペリア > コーナールーム"
+
+        it "identifies an empty hotel code by its one-based index" $ do
+            describeHotelConfigError "Hotels.dhall" (EmptyHotelCode 2)
+                `shouldBe`
+                    "Invalid hotel configuration in Hotels.dhall: hotel at index 2 has an empty code"
+
+        it "uses the readable configuration error for uncaught exception output" $ do
+            let configError = ZeroStayCount "TDH" ["スーペリア"]
+                exception = HotelConfigException "Hotels.dhall" configError
+            show exception `shouldBe` describeHotelConfigError "Hotels.dhall" configError
+
+    describe "renderHotelDetailsHtml" $ do
+        it "escapes detail labels before inserting them into generated HTML" $ do
+            renderHotelDetailsHtml [HDStay "</span><script>alert(1)</script>" 1]
+                `shouldBe`
+                    "<span class=\"hotel-detail-item hotel-detail-level-0\">&lt;/span&gt;&lt;script&gt;alert(1)&lt;/script&gt;</span>"
+
+            renderHotelDetailsHtml
+                [HDNode "</span><script>alert(2)</script>" [HDStay "safe" 1]]
+                `shouldBe` concat
+                    [ "<span class=\"hotel-detail-item hotel-detail-level-0\">&lt;/span&gt;&lt;script&gt;alert(2)&lt;/script&gt;</span>"
+                    , "<span class=\"hotel-detail-item hotel-detail-level-1\">safe</span>"
+                    ]
+
+        it "clamps detail nesting at the existing level-3 CSS class" $ do
+            let nestedDetails =
+                    [HDNode "0" [HDNode "1" [HDNode "2" [HDNode "3" [HDStay "4" 1]]]]]
+            renderHotelDetailsHtml nestedDetails `shouldBe` concat
+                [ detailSpan 0 "0"
+                , detailSpan 1 "1"
+                , detailSpan 2 "2"
+                , detailSpan 3 "3"
+                , detailSpan 3 "4"
+                ]
+
+    describe "Hotels.dhall" $ do
+        it "reads UTF-8 and resolves relative imports from the config directory" $
+            withSystemTempDirectory "hotel-config" $ \directory -> do
+                let configPath = directory </> "Hotels.dhall"
+                    importedPath = directory </> "Hotel.dhall"
+                writeUtf8File configPath "[ ./Hotel.dhall ]"
+                writeUtf8File importedPath relativeHotelConfig
+
+                hotels <- loadHotels configPath
+                map (\hotel -> (hotelCode hotel, hotelStayCount hotel)) hotels
+                    `shouldBe` [("TDH", 2)]
+
+        -- These production-data assertions are an intentional migration baseline.
+        -- Update them together whenever the authored hotel breakdown changes.
+        it "loads a regular FilePath and preserves current stay totals" $ do
+            assertProductionHotelConfigExists
+            hotels <- loadHotels productionHotelsPath
+            map (\hotel -> (hotelCode hotel, hotelStayCount hotel)) (sortOn hotelCode hotels)
+                `shouldBe` [("DHM", 5), ("FSH", 7), ("TDH", 6), ("TSH", 3)]
+            sum (map hotelStayCount hotels) `shouldBe` 21
+
+        it "renders the production hotel details exactly as before the migration" $ do
+            assertProductionHotelConfigExists
+            hotels <- loadHotels productionHotelsPath
+            map (\hotel -> (hotelCode hotel, renderHotelDetailsHtml $ details hotel)) hotels
+                `shouldBe` expectedHotelDetailsHtml
+
+        it "reports validation failures with the source path and readable reason" $
+            withSystemTempFile "Hotels-invalid.dhall" $ \path handle -> do
+                hSetEncoding handle utf8
+                hPutStr handle invalidHotelConfig
+                hClose handle
+                loadHotels path `shouldThrow` readableHotelConfigError path
+
+        it "reports invalid UTF-8 with the source path and readable reason" $
+            withSystemTempFile "Hotels-invalid-utf8.dhall" $ \path handle -> do
+                hSetBinaryMode handle True
+                hPutChar handle '\xFF'
+                hClose handle
+                loadHotels path `shouldThrow` invalidUtf8HotelConfigError path
+  where
+    hotelWith rawDetails = HotelRaw "TDH" rawDetails "#B95C00"
+    hotelWithCode code = hotelWithCodeAndDetails code [HotelStayRaw ["スーペリア"] 1]
+    hotelWithCodeAndDetails code rawDetails = HotelRaw code rawDetails "#B95C00"
+    hotelWithColor color = HotelRaw "TDH" [HotelStayRaw ["スーペリア"] 1] color
+
+assertProductionHotelConfigExists :: Expectation
+assertProductionHotelConfigExists = do
+    exists <- doesFileExist productionHotelsPath
+    unless exists $ expectationFailure $
+        "Production hotel config not found from the test working directory: "
+            ++ productionHotelsPath
+
+detailSpan :: Int -> String -> String
+detailSpan level text =
+    "<span class=\"hotel-detail-item hotel-detail-level-"
+        ++ show level
+        ++ "\">"
+        ++ text
+        ++ "</span>"
+
+expectedHotelDetailsHtml :: [(String, String)]
+-- Update this migration golden when the production hotel breakdown intentionally changes.
+expectedHotelDetailsHtml =
+    [ ( "FSH"
+      , concat
+          [ "<span class=\"hotel-detail-item hotel-detail-level-0\">ファンタジーシャトー</span>"
+          , "<span class=\"hotel-detail-item hotel-detail-level-1\">スプリングスサイド</span>"
+          , "<span class=\"hotel-detail-item hotel-detail-level-2\">バルアル</span>"
+          , "<span class=\"hotel-detail-item hotel-detail-level-1\">ローズコートサイド</span>"
+          , "<span class=\"hotel-detail-item hotel-detail-level-2\">スーペリア \x00D7\&3</span>"
+          , "<span class=\"hotel-detail-item hotel-detail-level-2\">スーペリア・アルコーヴ \x00D7\&2</span>"
+          , "<span class=\"hotel-detail-item hotel-detail-level-1\">べイエリアサイド</span>"
+          , "<span class=\"hotel-detail-item hotel-detail-level-2\">スーペリア・アルコーヴ</span>"
+          ]
+      )
+    , ( "DHM"
+      , concat
+          [ "<span class=\"hotel-detail-item hotel-detail-level-0\">スイート</span>"
+          , "<span class=\"hotel-detail-item hotel-detail-level-1\">ハバグラ</span>"
+          , "<span class=\"hotel-detail-item hotel-detail-level-1\">ハバテラ \x00D7\&2</span>"
+          , "<span class=\"hotel-detail-item hotel-detail-level-1\">ピアバル</span>"
+          , "<span class=\"hotel-detail-item hotel-detail-level-0\">ポルトパラディーゾ</span>"
+          , "<span class=\"hotel-detail-item hotel-detail-level-1\">スーペリアルームハーバービュー</span>"
+          ]
+      )
+    , ( "TDH"
+      , concat
+          [ "<span class=\"hotel-detail-item hotel-detail-level-0\">キャラ</span>"
+          , "<span class=\"hotel-detail-item hotel-detail-level-1\">美女野獣</span>"
+          , "<span class=\"hotel-detail-item hotel-detail-level-1\">シンデレラ</span>"
+          , "<span class=\"hotel-detail-item hotel-detail-level-0\">スーペリア</span>"
+          , "<span class=\"hotel-detail-item hotel-detail-level-1\">コーナールーム \x00D7\&2</span>"
+          , "<span class=\"hotel-detail-item hotel-detail-level-1\">パークグランドビュー</span>"
+          , "<span class=\"hotel-detail-item hotel-detail-level-0\">コンシェルジュ</span>"
+          , "<span class=\"hotel-detail-item hotel-detail-level-1\">バルコニールーム パークグランドビュー</span>"
+          ]
+      )
+    , ( "TSH"
+      , "<span class=\"hotel-detail-item hotel-detail-level-0\">スタンダードルーム \x00D7\&3</span>"
+      )
+    ]
+
+invalidHotelConfig :: String
+invalidHotelConfig =
+    "[ { hotelCodeRaw = \"TDH\", detailsRaw = [ { detailPathRaw = [ \"スーペリア\" ], stayCountRaw = 0 } ], hotelColorRaw = \"#B95C00\" } ]"
+
+relativeHotelConfig :: String
+relativeHotelConfig =
+    "{ hotelCodeRaw = \"TDH\", detailsRaw = [ { detailPathRaw = [ \"スーペリア\" ], stayCountRaw = 2 } ], hotelColorRaw = \"#B95C00\" }"
+
+writeUtf8File :: FilePath -> String -> IO ()
+writeUtf8File path contents =
+    withFile path WriteMode $ \handle -> do
+        hSetEncoding handle utf8
+        hPutStr handle contents
+
+readableHotelConfigError :: FilePath -> HotelConfigException -> Bool
+readableHotelConfigError path (HotelConfigException actualPath configError) =
+    actualPath == path
+        && configError == ZeroStayCount "TDH" ["スーペリア"]
+
+invalidUtf8HotelConfigError :: FilePath -> HotelConfigException -> Bool
+invalidUtf8HotelConfigError path (HotelConfigException actualPath configError) =
+    actualPath == path
+        && case configError of
+            InvalidUtf8 reason -> not $ null reason
+            _                  -> False
+
+expectRight :: Show error => Either error value -> IO value
+expectRight result = case result of
+    Left err -> do
+        expectationFailure $ "Expected Right, got Left: " ++ show err
+        fail "unreachable"
+    Right value -> pure value
+
+expectSingleHotel :: Show error => Either error [Hotel] -> IO Hotel
+expectSingleHotel result = do
+    hotels <- expectRight result
+    case hotels of
+        [hotel] -> pure hotel
+        _ -> do
+            expectationFailure $ "Expected one hotel, got: " ++ show hotels
+            fail "unreachable"


### PR DESCRIPTION
## 概要

Disney宿泊情報の総宿泊数と内訳の手動同期を廃止し、型付きの宿泊内訳だけからホテル別・全体の宿泊数を導出します。表示内容とHTML構造は変更しません。

## 変更内容

- Hotels.dhallの各内訳をラベルと泊数の組として定義
- 手動設定していたstaysRawを削除
- 内訳の階層化、宿泊数集計、従来の ×N 表示をHaskell側で導出
- 空値、重複・競合パス、0泊、不正コード・色を検証
- LucidによるラベルのHTMLエスケープを追加
- Dhall設定を明示的なUTF-8として読み込み、相対importと構造化エラーを維持
- 現行のホテル別泊数と生成HTMLをゴールデンテストで固定

## 検証

- TypeScript: 141 tests passed
- Haskell: 183 examples passed
- HotelStay対象17 testsをLC_ALL=C / LANG=Cで実行して成功
- Dhall format / lint成功
- git diff --check成功
- LC_ALL=C / LANG=Cでサイト全体のrebuild成功
- 変更前後の宿泊表示HTMLが一致
- reviewer、security-reviewer、Claude reviewはいずれも指摘ゼロ